### PR TITLE
OpenAPI model classes - minimal implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
       "dev": true,
       "funding": [
         {
@@ -3467,30 +3467,30 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.0.tgz",
-      "integrity": "sha512-rNYfqfLC0L0zQKRKsg4n4J+W1A2fbyGH7Ss/kDIocp9KXD9iaL111glsLu7+Z7FHuZxwzInMDXq+N1ZIBkI/TQ==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.0",
-        "@jest/expect": "^28.1.0",
-        "@jest/test-result": "^28.1.0",
-        "@jest/types": "^28.1.0",
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.0",
-        "jest-matcher-utils": "^28.1.0",
-        "jest-message-util": "^28.1.0",
-        "jest-runtime": "^28.1.0",
-        "jest-snapshot": "^28.1.0",
-        "jest-util": "^28.1.0",
-        "pretty-format": "^28.1.0",
+        "jest-each": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
+        "stack-utils": "^2.0.3"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
@@ -3573,36 +3573,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/jest-diff": {
@@ -5397,12 +5367,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
-    "node_modules/throat": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
-      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
-      "dev": true
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5988,8 +5952,7 @@
     },
     "packages/json-api-model/node_modules/@fresha/api-tools-core": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
-      "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
+      "license": "MIT"
     },
     "packages/json-schema-codegen": {
       "name": "@fresha/json-schema-codegen",
@@ -6018,8 +5981,7 @@
     },
     "packages/json-schema-model/node_modules/@fresha/api-tools-core": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
-      "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
+      "license": "MIT"
     },
     "packages/openapi-codegen": {
       "name": "@fresha/openapi-codegen",
@@ -6093,6 +6055,7 @@
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "0.1.0",
+        "@fresha/json-schema-model": "0.1.0",
         "yaml": "^2.1.1"
       },
       "devDependencies": {
@@ -6138,16 +6101,14 @@
     },
     "tools/ci-config/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "tools/ci-config/node_modules/glob": {
       "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6164,8 +6125,7 @@
     },
     "tools/ci-config/node_modules/minimatch": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6204,9 +6164,8 @@
     },
     "tools/jest-config/node_modules/@types/jest": {
       "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.0.tgz",
-      "integrity": "sha512-ITfF6JJIl9zbEi2k6NmhNE/BiDqfsI/ceqfvdaWaPbcrCpYyyRq4KtDQIWh6vQUru6SqwppODiom/Zhid+np6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -6214,9 +6173,8 @@
     },
     "tools/jest-config/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6226,18 +6184,16 @@
     },
     "tools/jest-config/node_modules/diff-sequences": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "tools/jest-config/node_modules/jest": {
       "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.0.tgz",
-      "integrity": "sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^28.1.0",
         "import-local": "^3.0.2",
@@ -6258,11 +6214,102 @@
         }
       }
     },
+    "tools/jest-config/node_modules/jest-circus": {
+      "version": "28.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^28.1.0",
+        "@jest/expect": "^28.1.0",
+        "@jest/test-result": "^28.1.0",
+        "@jest/types": "^28.1.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^28.1.0",
+        "jest-matcher-utils": "^28.1.0",
+        "jest-message-util": "^28.1.0",
+        "jest-runtime": "^28.1.0",
+        "jest-snapshot": "^28.1.0",
+        "jest-util": "^28.1.0",
+        "pretty-format": "^28.1.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/jest-circus/node_modules/react-is": {
+      "version": "18.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "tools/jest-config/node_modules/jest-diff": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.5.1",
@@ -6275,18 +6322,16 @@
     },
     "tools/jest-config/node_modules/jest-get-type": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "tools/jest-config/node_modules/jest-matcher-utils": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^27.5.1",
@@ -6299,9 +6344,8 @@
     },
     "tools/jest-config/node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6313,15 +6357,13 @@
     },
     "tools/jest-config/node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "tools/jest-config/node_modules/semver": {
       "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6334,9 +6376,8 @@
     },
     "tools/jest-config/node_modules/ts-jest": {
       "version": "28.0.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.4.tgz",
-      "integrity": "sha512-S6uRDDdCJBvnZqyGjB4VCnwbQrbgdL8WPeP4jevVSpYsBaeGRQAIS08o3Svav2Ex+oXwLgJ/m7F24TNq62kA1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
@@ -6373,9 +6414,8 @@
     },
     "tools/jest-config/node_modules/yargs-parser": {
       "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -6961,16 +7001,12 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
           "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6981,8 +7017,6 @@
         },
         "minimatch": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -7046,8 +7080,6 @@
       "dependencies": {
         "@types/jest": {
           "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.0.tgz",
-          "integrity": "sha512-ITfF6JJIl9zbEi2k6NmhNE/BiDqfsI/ceqfvdaWaPbcrCpYyyRq4KtDQIWh6vQUru6SqwppODiom/Zhid+np6A==",
           "dev": true,
           "requires": {
             "jest-matcher-utils": "^27.0.0",
@@ -7056,20 +7088,14 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
         "diff-sequences": {
           "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-          "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
           "dev": true
         },
         "jest": {
           "version": "28.1.0",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.0.tgz",
-          "integrity": "sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==",
           "dev": true,
           "requires": {
             "@jest/core": "^28.1.0",
@@ -7077,10 +7103,77 @@
             "jest-cli": "^28.1.0"
           }
         },
+        "jest-circus": {
+          "version": "28.1.0",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.0",
+            "@jest/expect": "^28.1.0",
+            "@jest/test-result": "^28.1.0",
+            "@jest/types": "^28.1.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^0.7.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^28.1.0",
+            "jest-matcher-utils": "^28.1.0",
+            "jest-message-util": "^28.1.0",
+            "jest-runtime": "^28.1.0",
+            "jest-snapshot": "^28.1.0",
+            "jest-util": "^28.1.0",
+            "pretty-format": "^28.1.0",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3",
+            "throat": "^6.0.1"
+          },
+          "dependencies": {
+            "diff-sequences": {
+              "version": "28.1.1",
+              "dev": true
+            },
+            "jest-diff": {
+              "version": "28.1.3",
+              "dev": true,
+              "requires": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^28.1.1",
+                "jest-get-type": "^28.0.2",
+                "pretty-format": "^28.1.3"
+              }
+            },
+            "jest-get-type": {
+              "version": "28.0.2",
+              "dev": true
+            },
+            "jest-matcher-utils": {
+              "version": "28.1.3",
+              "dev": true,
+              "requires": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^28.1.3",
+                "jest-get-type": "^28.0.2",
+                "pretty-format": "^28.1.3"
+              }
+            },
+            "pretty-format": {
+              "version": "28.1.3",
+              "dev": true,
+              "requires": {
+                "@jest/schemas": "^28.1.3",
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+              }
+            },
+            "react-is": {
+              "version": "18.2.0",
+              "dev": true
+            }
+          }
+        },
         "jest-diff": {
           "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-          "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
@@ -7091,14 +7184,10 @@
         },
         "jest-get-type": {
           "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-          "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
           "dev": true
         },
         "jest-matcher-utils": {
           "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-          "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
@@ -7109,8 +7198,6 @@
         },
         "pretty-format": {
           "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1",
@@ -7120,14 +7207,10 @@
         },
         "react-is": {
           "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         },
         "semver": {
           "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7135,8 +7218,6 @@
         },
         "ts-jest": {
           "version": "28.0.4",
-          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.4.tgz",
-          "integrity": "sha512-S6uRDDdCJBvnZqyGjB4VCnwbQrbgdL8WPeP4jevVSpYsBaeGRQAIS08o3Svav2Ex+oXwLgJ/m7F24TNq62kA1A==",
           "dev": true,
           "requires": {
             "bs-logger": "0.x",
@@ -7151,8 +7232,6 @@
         },
         "yargs-parser": {
           "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -7178,9 +7257,7 @@
       },
       "dependencies": {
         "@fresha/api-tools-core": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
-          "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
+          "version": "0.1.0"
         }
       }
     },
@@ -7204,9 +7281,7 @@
       },
       "dependencies": {
         "@fresha/api-tools-core": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
-          "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
+          "version": "0.1.0"
         }
       }
     },
@@ -7270,6 +7345,7 @@
         "@fresha/api-tools-core": "0.1.1",
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
+        "@fresha/json-schema-model": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "@types/node": "^18.0.0",
         "deep-object-diff": "^1.1.7",
@@ -8119,9 +8195,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001402",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
-      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
+      "version": "1.0.30001406",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
+      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
       "dev": true
     },
     "chalk": {
@@ -9252,30 +9328,30 @@
       }
     },
     "jest-circus": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.0.tgz",
-      "integrity": "sha512-rNYfqfLC0L0zQKRKsg4n4J+W1A2fbyGH7Ss/kDIocp9KXD9iaL111glsLu7+Z7FHuZxwzInMDXq+N1ZIBkI/TQ==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.0",
-        "@jest/expect": "^28.1.0",
-        "@jest/test-result": "^28.1.0",
-        "@jest/types": "^28.1.0",
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.0",
-        "jest-matcher-utils": "^28.1.0",
-        "jest-message-util": "^28.1.0",
-        "jest-runtime": "^28.1.0",
-        "jest-snapshot": "^28.1.0",
-        "jest-util": "^28.1.0",
-        "pretty-format": "^28.1.0",
+        "jest-each": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
+        "stack-utils": "^2.0.3"
       }
     },
     "jest-cli": {
@@ -9326,35 +9402,6 @@
         "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "jest-circus": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-          "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^28.1.3",
-            "@jest/expect": "^28.1.3",
-            "@jest/test-result": "^28.1.3",
-            "@jest/types": "^28.1.3",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "co": "^4.6.0",
-            "dedent": "^0.7.0",
-            "is-generator-fn": "^2.0.0",
-            "jest-each": "^28.1.3",
-            "jest-matcher-utils": "^28.1.3",
-            "jest-message-util": "^28.1.3",
-            "jest-runtime": "^28.1.3",
-            "jest-snapshot": "^28.1.3",
-            "jest-util": "^28.1.3",
-            "p-limit": "^3.1.0",
-            "pretty-format": "^28.1.3",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3"
-          }
-        }
       }
     },
     "jest-diff": {
@@ -10689,12 +10736,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
-    },
-    "throat": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
-      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
-      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",

--- a/packages/openapi-model/examples/api.yaml
+++ b/packages/openapi-model/examples/api.yaml
@@ -1,0 +1,170 @@
+openapi: "3.0.3"
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples: 
+                foo:
+                  value:
+                    {
+                      "versions": [
+                        {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                      ]
+                    }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json: 
+              examples: 
+                foo:
+                  value: |
+                   {
+                    "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                   }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }

--- a/packages/openapi-model/examples/callback.yaml
+++ b/packages/openapi-model/examples/callback.yaml
@@ -1,0 +1,59 @@
+openapi: 3.0.3
+info:
+  title: Callback Example
+  version: 1.0.0
+paths:
+  /streams:
+    post:
+      description: subscribes a client to receive out-of-band data
+      parameters:
+        - name: callbackUrl
+          in: query
+          required: true
+          description: |
+            the location where data will be sent.  Must be network accessible
+            by the source server
+          schema:
+            type: string
+            format: uri
+            example: https://tonys-server.com
+      responses:
+        '201':
+          description: subscription successfully created
+          content:
+            application/json:
+              schema:
+                type: object
+                description: subscription information
+                required:
+                  - subscriptionId
+                properties:
+                  subscriptionId:
+                    description: this unique identifier allows management of the subscription
+                    type: string
+                    example: 2531329f-fb09-4ef7-887e-84e648214436
+      callbacks:
+        onData:
+          '{$request.query.callbackUrl}/data':
+            post:
+              requestBody:
+                description: subscription payload
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        timestamp:
+                          type: string
+                          format: date-time
+                        userData:
+                          type: string
+              responses:
+                '202':
+                  description: |
+                    Your server implementation should return this HTTP status code
+                    if the data was received successfully
+                '204':
+                  description: |
+                    Your server should return this HTTP status code if no longer interested
+                    in further updates

--- a/packages/openapi-model/examples/link.yaml
+++ b/packages/openapi-model/examples/link.yaml
@@ -1,0 +1,199 @@
+openapi: 3.0.3
+info:
+  title: Link Example
+  version: 1.0.0
+paths:
+  /2.0/users/{username}:
+    get:
+      operationId: getUserByName
+      parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+          links:
+            userRepositories:
+              $ref: '#/components/links/UserRepositories'
+  /2.0/repositories/{username}:
+    get:
+      operationId: getRepositoriesByOwner
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: repositories owned by the supplied user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/repository'
+          links:
+            userRepository:
+              $ref: '#/components/links/UserRepository'
+  /2.0/repositories/{username}/{slug}:
+    get:
+      operationId: getRepository
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The repository
+          content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/repository'
+          links:
+            repositoryPullRequests:
+              $ref: '#/components/links/RepositoryPullRequests'
+  /2.0/repositories/{username}/{slug}/pullrequests:
+    get:
+      operationId: getPullRequestsByRepository
+      parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: state
+        in: query
+        schema:
+          type: string
+          enum:
+            - open
+            - merged
+            - declined
+      responses:
+        '200':
+          description: an array of pull request objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/pullrequest'
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}:
+    get:
+      operationId: getPullRequestsById
+      parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: a pull request object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pullrequest'
+          links:
+            pullRequestMerge:
+              $ref: '#/components/links/PullRequestMerge'
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge:
+    post:
+      operationId: mergePullRequest
+      parameters:
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: the PR was successfully merged
+components:
+  links:
+    UserRepositories:
+      operationId: getRepositoriesByOwner
+      parameters:
+        username: $response.body#/username
+    UserRepository:
+      operationId: getRepository
+      parameters:
+        username: $response.body#/owner/username
+        slug: $response.body#/slug
+    RepositoryPullRequests:
+      operationId: getPullRequestsByRepository
+      parameters:
+          username: $response.body#/owner/username
+          slug: $response.body#/slug
+    PullRequestMerge:
+      operationId: mergePullRequest
+      parameters:
+        username: $response.body#/author/username
+        slug: $response.body#/repository/slug
+        pid: $response.body#/id
+  schemas:
+    user:
+      type: object
+      properties:
+        username:
+          type: string
+        uuid:
+          type: string
+    repository:
+      type: object
+      properties:
+        slug:
+          type: string
+        owner:
+          $ref: '#/components/schemas/user'
+    pullrequest:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        repository:
+          $ref: '#/components/schemas/repository'
+        author:
+          $ref: '#/components/schemas/user'

--- a/packages/openapi-model/examples/petstore.yaml
+++ b/packages/openapi-model/examples/petstore.yaml
@@ -1,0 +1,160 @@
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of pet to fetch
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of pet to delete
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+tags:
+  - name: tag1
+    description: The first tag
+  - name: tag2
+    description: Second tag

--- a/packages/openapi-model/examples/simple.yaml
+++ b/packages/openapi-model/examples/simple.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Sample API
+  description: A sample API to illustrate OpenAPI concepts
+paths:
+  /list:
+    get:
+      description: Returns a list of stuff              
+      responses:
+        '200':
+          description: Successful response

--- a/packages/openapi-model/examples/uspto.yaml
+++ b/packages/openapi-model/examples/uspto.yaml
@@ -1,0 +1,210 @@
+openapi: 3.0.3
+servers:
+  - url: '{scheme}://developer.uspto.gov/ds-api'
+    variables:
+      scheme:
+        description: 'The Data Set API is accessible via https and http'
+        enum:
+          - 'https'
+          - 'http'
+        default: 'https'
+info:
+  description: >-
+    The Data Set API (DSAPI) allows the public users to discover and search
+    USPTO exported data sets. This is a generic API that allows USPTO users to
+    make any CSV based data files searchable through API. With the help of GET
+    call, it returns the list of data fields that are searchable. With the help
+    of POST call, data can be fetched based on the filters on the field names.
+    Please note that POST call is used to search the actual data. The reason for
+    the POST call is that it allows users to specify any complex search criteria
+    without worry about the GET size limitations as well as encoding of the
+    input parameters.
+  version: 1.0.0
+  title: USPTO Data Set API
+  contact:
+    name: Open Data Portal
+    url: 'https://developer.uspto.gov'
+    email: developer@uspto.gov
+tags:
+  - name: metadata
+    description: Find out about the data sets
+  - name: search
+    description: Search a data set
+paths:
+  /:
+    get:
+      tags:
+        - metadata
+      operationId: list-data-sets
+      summary: List available data sets
+      responses:
+        '200':
+          description: Returns a list of data sets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dataSetList'
+              example:
+                {
+                  "total": 2,
+                  "apis": [
+                    {
+                      "apiKey": "oa_citations",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+                    },
+                    {
+                      "apiKey": "cancer_moonshot",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+                    }
+                  ]
+                }
+  /{dataset}/{version}/fields:
+    get:
+      tags:
+        - metadata
+      summary: >-
+        Provides the general information about the API and the list of fields
+        that can be used to query the dataset.
+      description: >-
+        This GET API returns the list of all the searchable field names that are
+        in the oa_citations. Please see the 'fields' attribute which returns an
+        array of field names. Each field or a combination of fields can be
+        searched using the syntax options shown below.
+      operationId: list-searchable-fields
+      parameters:
+        - name: dataset
+          in: path
+          required: true
+          description: 'Name of the dataset.'
+          example: "oa_citations"
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          description: Version of the dataset.
+          example: "v1"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            The dataset API for the given version is found and it is accessible
+            to consume.
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: >-
+            The combination of dataset name and version is not found in the
+            system or it is not published yet to be consumed by public.
+          content:
+            application/json:
+              schema:
+                type: string
+  /{dataset}/{version}/records:
+    post:
+      tags:
+        - search
+      summary: >-
+        Provides search capability for the data set with the given search
+        criteria.
+      description: >-
+        This API is based on Solr/Lucene Search. The data is indexed using
+        SOLR. This GET API returns the list of all the searchable field names
+        that are in the Solr Index. Please see the 'fields' attribute which
+        returns an array of field names. Each field or a combination of fields
+        can be searched using the Solr/Lucene Syntax. Please refer
+        https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for
+        the query syntax. List of field names that are searchable can be
+        determined using above GET api.
+      operationId: perform-search
+      parameters:
+        - name: version
+          in: path
+          required: true
+          description: Version of the dataset.
+          schema:
+            type: string
+            default: v1
+        - name: dataset
+          in: path
+          required: true
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          schema:
+            type: string
+            default: oa_citations
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: object
+        '404':
+          description: No matching record found for the given criteria.
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                criteria:
+                  description: >-
+                    Uses Lucene Query Syntax in the format of
+                    propertyName:value, propertyName:[num1 TO num2] and date
+                    range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the
+                    response please see the 'docs' element which has the list of
+                    record objects. Each record structure would consist of all
+                    the fields and their corresponding values.
+                  type: string
+                  default: '*:*'
+                start:
+                  description: Starting record number. Default value is 0.
+                  type: integer
+                  default: 0
+                rows:
+                  description: >-
+                    Specify number of rows to be returned. If you run the search
+                    with default values, in the response you will see 'numFound'
+                    attribute which will tell the number of records available in
+                    the dataset.
+                  type: integer
+                  default: 100
+              required:
+                - criteria
+components:
+  schemas:
+    dataSetList:
+      type: object
+      properties:
+        total:
+          type: integer
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              apiKey:
+                type: string
+                description: To be used as a dataset parameter value
+              apiVersionNumber:
+                type: string
+                description: To be used as a version parameter value
+              apiUrl:
+                type: string
+                format: uriref
+                description: "The URL describing the dataset's fields"
+              apiDocumentationUrl:
+                type: string
+                format: uriref
+                description: A URL to the API console for each API

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -45,6 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "0.1.0",
+    "@fresha/json-schema-model": "0.1.0",
     "yaml": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/openapi-model/src/3.0.3/index.ts
+++ b/packages/openapi-model/src/3.0.3/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './model';

--- a/packages/openapi-model/src/3.0.3/model/BasicNode.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/BasicNode.test.ts
@@ -1,0 +1,28 @@
+/* eslint-disable max-classes-per-file */
+import { BasicNode } from './BasicNode';
+import { OpenAPI } from './OpenAPI';
+
+type BranchParent = OpenAPI | Branch;
+
+class Branch extends BasicNode<BranchParent> {}
+class Leaf extends BasicNode<Branch> {}
+
+let parent: OpenAPI;
+
+beforeEach(() => {
+  parent = new OpenAPI('BasicNode.test', '0.0.1');
+});
+
+describe('parent-child relationships', () => {
+  it('should allow iterate up to the root', () => {
+    const branch0 = new Branch(parent);
+
+    const branch1 = new Branch(branch0);
+    const branch1Leaf = new Leaf(branch1);
+    const branch2 = new Branch(branch1);
+    const branch2Leaf = new Leaf(branch2);
+
+    expect(branch1Leaf.parent.parent).toBe(branch0);
+    expect(branch2Leaf.parent.parent).toBe(branch1);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/BasicNode.ts
+++ b/packages/openapi-model/src/3.0.3/model/BasicNode.ts
@@ -1,0 +1,38 @@
+import type { OpenAPI } from './OpenAPI';
+import type { Disposable, SpecificationExtensionsModel } from './types';
+import type { JSONValue } from '@fresha/api-tools-core';
+
+export interface TreeParent {
+  root: OpenAPI;
+}
+
+export type ExtensionFields = Map<string, JSONValue>;
+
+export class BasicNode<TParent extends TreeParent>
+  implements TreeParent, Disposable, SpecificationExtensionsModel
+{
+  root: OpenAPI;
+  parent: TParent;
+  readonly extensions: ExtensionFields;
+
+  constructor(parent: TParent) {
+    this.parent = parent;
+    this.root = parent.root;
+    this.extensions = new Map<string, JSONValue>();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  dispose(): void {}
+
+  setExtension(key: string, value: JSONValue): void {
+    this.extensions.set(key, value);
+  }
+
+  deleteExtension(key: string): void {
+    this.extensions.delete(key);
+  }
+
+  clearExtensions(): void {
+    this.extensions.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Callback.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.ts
@@ -1,0 +1,20 @@
+import { BasicNode } from './BasicNode';
+
+import type { Components } from './Components';
+import type { Operation } from './Operation';
+import type { PathItem } from './PathItem';
+import type { ParametrisedURLString, CallbackModel } from './types';
+
+export type CallbackParent = Components | Operation;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#callback-object
+ */
+export class Callback extends BasicNode<CallbackParent> implements CallbackModel {
+  readonly paths: Map<ParametrisedURLString, PathItem>;
+
+  constructor(parent: CallbackParent) {
+    super(parent);
+    this.paths = new Map<ParametrisedURLString, PathItem>();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Components.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.test.ts
@@ -1,0 +1,271 @@
+import { OpenAPI } from './OpenAPI';
+
+let { components } = new OpenAPI('Example', '0.1.0');
+
+beforeEach(() => {
+  components = new OpenAPI('Example', '0.1.0').components;
+});
+
+describe('schemas', () => {
+  beforeEach(() => {
+    components.setSchema('Integer', 'integer');
+    components.setSchema('Empty');
+  });
+
+  test('setSchema', () => {
+    expect(components.schemas.size).toBe(2);
+
+    const integerSchema = components.schemas.get('Integer');
+    expect(integerSchema).toHaveProperty('parent', components);
+
+    const emptySchema = components.schemas.get('Empty');
+    expect(emptySchema).toHaveProperty('parent', components);
+  });
+
+  test('deleteSchema', () => {
+    components.deleteSchema('Empty');
+    expect(Array.from(components.schemas.keys())).toStrictEqual(['Integer']);
+  });
+
+  test('clearSchemas', () => {
+    components.clearSchemas();
+    expect(components.schemas.size).toBe(0);
+  });
+});
+
+describe('responses', () => {
+  beforeEach(() => {
+    components.setResponse('Success', 'Success response');
+    components.setResponse('Error500', 'Error 5xx');
+  });
+
+  test('setResponse', () => {
+    expect(components.responses.size).toBe(2);
+
+    const successResponse = components.responses.get('Success');
+    expect(successResponse).toHaveProperty('parent', components);
+
+    const errorResponse = components.responses.get('Error500');
+    expect(errorResponse).toHaveProperty('parent', components);
+  });
+
+  test('deleteResponse', () => {
+    components.deleteResponse('Success');
+
+    expect(Array.from(components.responses.keys())).toStrictEqual(['Error500']);
+  });
+
+  test('clearResponses', () => {
+    components.clearResponses();
+
+    expect(components.responses.size).toBe(0);
+  });
+});
+
+describe('parameters', () => {
+  beforeEach(() => {
+    components.setParameter('ID', 'path', 'id');
+    components.setParameter('Offset', 'query', 'offset');
+    components.setParameter('Language', 'header', 'Language');
+    components.setParameter('SessionID', 'cookie', 'session');
+  });
+
+  test('setParameter', () => {
+    expect(components.parameters.size).toBe(4);
+
+    const idParam = components.parameters.get('ID');
+    expect(idParam).toHaveProperty('parent', components);
+    expect(idParam).toHaveProperty('in', 'path');
+    expect(idParam).toHaveProperty('name', 'id');
+
+    const offsetParam = components.parameters.get('Offset');
+    expect(offsetParam).toHaveProperty('parent', components);
+    expect(offsetParam).toHaveProperty('in', 'query');
+    expect(offsetParam).toHaveProperty('name', 'offset');
+
+    const languageParam = components.parameters.get('Language');
+    expect(languageParam).toHaveProperty('parent', components);
+    expect(languageParam).toHaveProperty('in', 'header');
+    expect(languageParam).toHaveProperty('name', 'Language');
+
+    const sessionParam = components.parameters.get('SessionID');
+    expect(sessionParam).toHaveProperty('parent', components);
+    expect(sessionParam).toHaveProperty('in', 'cookie');
+    expect(sessionParam).toHaveProperty('name', 'session');
+  });
+
+  test('deleteParameter', () => {
+    components.deleteParameter('ID');
+
+    expect(components.parameters.size).toBe(3);
+
+    expect(Array.from(components.parameters.keys())).toStrictEqual([
+      'Offset',
+      'Language',
+      'SessionID',
+    ]);
+  });
+
+  test('clearParameters', () => {
+    components.clearParameters();
+
+    expect(components.parameters.size).toBe(0);
+  });
+});
+
+describe('examples', () => {
+  beforeEach(() => {
+    components.setExample('Success');
+    components.setExample('Error');
+  });
+
+  test('setExample', () => {
+    expect(components.examples.size).toBe(2);
+    expect(components.examples.get('Success')).toHaveProperty('parent', components);
+    expect(components.examples.get('Error')).toHaveProperty('parent', components);
+  });
+
+  test('deleteExample', () => {
+    components.deleteExample('Success');
+
+    expect(components.examples.size).toBe(1);
+    expect(components.examples.get('Error')).toBeTruthy();
+  });
+
+  test('clearExamples', () => {
+    components.clearExamples();
+
+    expect(components.examples.size).toBe(0);
+  });
+});
+
+describe('requestBodies', () => {
+  beforeEach(() => {
+    components.setRequestBody('Empty');
+    components.setRequestBody('List');
+  });
+
+  test('setRequestBody', () => {
+    expect(components.requestBodies.size).toBe(2);
+    expect(components.requestBodies.get('Empty')).toHaveProperty('parent', components);
+    expect(components.requestBodies.get('List')).toHaveProperty('parent', components);
+  });
+
+  test('deleteRequestBody', () => {
+    components.deleteRequestBody('Empty');
+
+    expect(components.requestBodies.size).toBe(1);
+    expect(components.requestBodies.get('List')).toBeTruthy();
+  });
+
+  test('clearRequestBodies', () => {
+    components.clearRequestBodies();
+
+    expect(components.requestBodies.size).toBe(0);
+  });
+});
+
+describe('headers', () => {
+  beforeEach(() => {
+    components.setHeader('X-Language');
+    components.setHeader('X-Fresha');
+  });
+
+  test('setHeader', () => {
+    expect(components.headers.size).toBe(2);
+    expect(components.headers.get('X-Language')).toHaveProperty('parent', components);
+    expect(components.headers.get('X-Fresha')).toHaveProperty('parent', components);
+  });
+
+  test('deleteHeader', () => {
+    components.deleteHeader('X-Language');
+
+    expect(components.headers.size).toBe(1);
+    expect(components.headers.get('X-Fresha')).toBeTruthy();
+  });
+
+  test('clearHeaders', () => {
+    components.clearHeaders();
+
+    expect(components.headers.size).toBe(0);
+  });
+});
+
+describe('securitySchemas', () => {
+  beforeEach(() => {
+    components.setSecuritySchema('local', 'apiKey');
+    components.setSecuritySchema('google', 'oauth2');
+  });
+
+  test('setSecuritySchema', () => {
+    expect(components.securitySchemas.size).toBe(2);
+    expect(components.securitySchemas.get('local')).toHaveProperty('parent', components);
+    expect(components.securitySchemas.get('google')).toHaveProperty('parent', components);
+  });
+
+  test('deleteSecuritySchema', () => {
+    components.deleteSecuritySchema('local');
+
+    expect(components.securitySchemas.size).toBe(1);
+    expect(components.securitySchemas.get('google')).toBeTruthy();
+    expect(components.securitySchemas.get('google')).toHaveProperty('type', 'oauth2');
+  });
+
+  test('clearSecuritySchemas', () => {
+    components.clearSecuritySchemas();
+
+    expect(components.securitySchemas.size).toBe(0);
+  });
+});
+
+describe('links', () => {
+  beforeEach(() => {
+    components.setLink('Language');
+    components.setLink('Fresha');
+  });
+
+  test('setLink', () => {
+    expect(components.links.size).toBe(2);
+    expect(components.links.get('Language')).toHaveProperty('parent', components);
+    expect(components.links.get('Fresha')).toHaveProperty('parent', components);
+  });
+
+  test('deleteLink', () => {
+    components.deleteLink('Language');
+
+    expect(components.links.size).toBe(1);
+    expect(components.links.get('Fresha')).toBeTruthy();
+  });
+
+  test('clearLinks', () => {
+    components.clearLinks();
+
+    expect(components.links.size).toBe(0);
+  });
+});
+
+describe('callbacks', () => {
+  beforeEach(() => {
+    components.setCallback('Language');
+    components.setCallback('Fresha');
+  });
+
+  test('setCallback', () => {
+    expect(components.callbacks.size).toBe(2);
+    expect(components.callbacks.get('Language')).toHaveProperty('parent', components);
+    expect(components.callbacks.get('Fresha')).toHaveProperty('parent', components);
+  });
+
+  test('deleteCallback', () => {
+    components.deleteCallback('Language');
+
+    expect(components.callbacks.size).toBe(1);
+    expect(components.callbacks.get('Fresha')).toBeTruthy();
+  });
+
+  test('clearCallbacks', () => {
+    components.clearCallbacks();
+
+    expect(components.callbacks.size).toBe(0);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -1,0 +1,235 @@
+import { BasicNode } from './BasicNode';
+import { Callback } from './Callback';
+import { Example } from './Example';
+import { Header } from './Header';
+import { Link } from './Link';
+import { CookieParameter } from './Parameter/CookieParameter';
+import { HeaderParameter } from './Parameter/HeaderParameter';
+import { PathParameter } from './Parameter/PathParameter';
+import { QueryParameter } from './Parameter/QueryParameter';
+import { RequestBody } from './RequestBody';
+import { Response } from './Response';
+import { Schema, SchemaFactory } from './Schema';
+import { ApiKeyScheme } from './SecurityScheme/ApiKeyScheme';
+import { HttpScheme } from './SecurityScheme/HttpScheme';
+import { OAuth2Scheme } from './SecurityScheme/OAuth2Scheme';
+import { OpenIdConnectScheme } from './SecurityScheme/OpenIdConnectScheme';
+
+import type { OpenAPI } from './OpenAPI';
+import type { SecurityScheme } from './SecurityScheme';
+import type {
+  CallbackModel,
+  ComponentsModel,
+  ExampleModel,
+  HeaderModel,
+  LinkModel,
+  ParameterModel,
+  RequestBodyModel,
+  ResponseModel,
+  SchemaCreateType,
+  SchemaModel,
+  SecuritySchemaModel,
+} from './types';
+import type { CommonMarkString } from '@fresha/api-tools-core';
+
+type AllParameters = PathParameter | QueryParameter | HeaderParameter | CookieParameter;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#components-object
+ */
+export class Components extends BasicNode<OpenAPI> implements ComponentsModel {
+  readonly schemas: Map<string, Schema>;
+  readonly responses: Map<string, Response>;
+  readonly parameters: Map<string, AllParameters>;
+  readonly examples: Map<string, Example>;
+  readonly requestBodies: Map<string, RequestBody>;
+  readonly headers: Map<string, Header>;
+  readonly securitySchemas: Map<string, SecurityScheme>;
+  readonly links: Map<string, Link>;
+  readonly callbacks: Map<string, Callback>;
+
+  constructor(parent: OpenAPI) {
+    super(parent);
+    this.schemas = new Map<string, Schema>();
+    this.responses = new Map<string, Response>();
+    this.parameters = new Map<string, AllParameters>();
+    this.examples = new Map<string, Example>();
+    this.requestBodies = new Map<string, RequestBody>();
+    this.headers = new Map<string, Header>();
+    this.securitySchemas = new Map<string, SecurityScheme>();
+    this.links = new Map<string, Link>();
+    this.callbacks = new Map<string, Callback>();
+  }
+
+  isEmpty(): boolean {
+    return (
+      !this.schemas.size &&
+      !this.responses.size &&
+      !this.parameters.size &&
+      !this.examples.size &&
+      !this.requestBodies.size &&
+      !this.headers.size &&
+      !this.securitySchemas.size &&
+      !this.links.size &&
+      !this.callbacks.size
+    );
+  }
+
+  setSchema(name: string, type?: SchemaCreateType): SchemaModel {
+    const result = SchemaFactory.create(this, type ?? null) as Schema;
+    this.schemas.set(name, result);
+    return result;
+  }
+
+  deleteSchema(name: string): void {
+    this.schemas.delete(name);
+  }
+
+  clearSchemas(): void {
+    this.schemas.clear();
+  }
+
+  setResponse(name: string, description: CommonMarkString): ResponseModel {
+    const result = new Response(this, description);
+    this.responses.set(name, result);
+    return result;
+  }
+
+  deleteResponse(name: string): void {
+    this.responses.delete(name);
+  }
+
+  clearResponses(): void {
+    this.responses.clear();
+  }
+
+  setParameter(name: string, kind: ParameterModel['in'], paramName: string): ParameterModel {
+    let result: PathParameter | QueryParameter | HeaderParameter | CookieParameter;
+    switch (kind) {
+      case 'path':
+        result = new PathParameter(this, paramName);
+        break;
+      case 'query':
+        result = new QueryParameter(this, paramName);
+        break;
+      case 'header':
+        result = new HeaderParameter(this, paramName);
+        break;
+      case 'cookie':
+        result = new CookieParameter(this, paramName);
+        break;
+      default:
+        throw new Error(`Unknown parameter type ${String(kind)}`);
+    }
+    this.parameters.set(name, result);
+    return result;
+  }
+
+  deleteParameter(name: string): void {
+    this.parameters.delete(name);
+  }
+
+  clearParameters(): void {
+    this.parameters.clear();
+  }
+
+  setExample(name: string): ExampleModel {
+    const example = new Example(this);
+    this.examples.set(name, example);
+    return example;
+  }
+
+  deleteExample(name: string): void {
+    this.examples.delete(name);
+  }
+
+  clearExamples(): void {
+    this.examples.clear();
+  }
+
+  setRequestBody(name: string): RequestBodyModel {
+    const result = new RequestBody(this);
+    this.requestBodies.set(name, result);
+    return result;
+  }
+
+  deleteRequestBody(name: string): void {
+    this.requestBodies.delete(name);
+  }
+
+  clearRequestBodies(): void {
+    this.requestBodies.clear();
+  }
+
+  setHeader(name: string): HeaderModel {
+    const result = new Header(this);
+    this.headers.set(name, result);
+    return result;
+  }
+
+  deleteHeader(name: string): void {
+    this.headers.delete(name);
+  }
+
+  clearHeaders(): void {
+    this.headers.clear();
+  }
+
+  setSecuritySchema(name: string, kind: SecuritySchemaModel['type']): SecuritySchemaModel {
+    let result: SecurityScheme;
+    switch (kind) {
+      case 'apiKey':
+        result = new ApiKeyScheme(this, 'x', 'header');
+        break;
+      case 'http':
+        result = new HttpScheme(this, Schema.create(this));
+        break;
+      case 'oauth2':
+        result = new OAuth2Scheme(this);
+        break;
+      case 'openIdConnect':
+        result = new OpenIdConnectScheme(this, 'http://www.example.com');
+        break;
+      default:
+        throw new Error(`Unsupported security scheme type ${String(kind)}`);
+    }
+    this.securitySchemas.set(name, result);
+    return result;
+  }
+
+  deleteSecuritySchema(name: string): void {
+    this.securitySchemas.delete(name);
+  }
+
+  clearSecuritySchemas(): void {
+    this.securitySchemas.clear();
+  }
+
+  setLink(name: string): LinkModel {
+    const result = new Link(this);
+    this.links.set(name, result);
+    return result;
+  }
+
+  deleteLink(name: string): void {
+    this.links.delete(name);
+  }
+
+  clearLinks(): void {
+    this.links.clear();
+  }
+
+  setCallback(name: string): CallbackModel {
+    const result = new Callback(this);
+    this.callbacks.set(name, result);
+    return result;
+  }
+
+  deleteCallback(name: string): void {
+    this.callbacks.delete(name);
+  }
+
+  clearCallbacks(): void {
+    this.callbacks.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Contact.ts
+++ b/packages/openapi-model/src/3.0.3/model/Contact.ts
@@ -1,0 +1,23 @@
+import { BasicNode } from './BasicNode';
+
+import type { Info } from './Info';
+import type { ContactModel } from './types';
+import type { Nullable, URLString, EmailString } from '@fresha/api-tools-core';
+
+export type ContactParent = Info;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#contact-object
+ */
+export class Contact extends BasicNode<ContactParent> implements ContactModel {
+  name: Nullable<string>;
+  url: Nullable<URLString>;
+  email: Nullable<EmailString>;
+
+  constructor(parent: ContactParent) {
+    super(parent);
+    this.name = null;
+    this.url = null;
+    this.email = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Discriminator.ts
+++ b/packages/openapi-model/src/3.0.3/model/Discriminator.ts
@@ -1,0 +1,20 @@
+import { BasicNode } from './BasicNode';
+
+import type { Schema } from './Schema';
+import type { DiscriminatorModel } from './types';
+
+export type DiscriminatorParent = Schema;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#discriminator-object
+ */
+export class Discriminator extends BasicNode<DiscriminatorParent> implements DiscriminatorModel {
+  propertyName: string;
+  readonly mapping: Map<string, string>;
+
+  constructor(parent: Schema, propertyName: string) {
+    super(parent);
+    this.propertyName = propertyName;
+    this.mapping = new Map<string, string>();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Encoding.ts
+++ b/packages/openapi-model/src/3.0.3/model/Encoding.ts
@@ -1,0 +1,29 @@
+import { BasicNode } from './BasicNode';
+
+import type { Header } from './Header';
+import type { MediaType } from './MediaType';
+import type { EncodingModel } from './types';
+
+export type EncodingParent = MediaType;
+
+export type SerializationStyle = 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#encoding-object
+ */
+export class Encoding extends BasicNode<EncodingParent> implements EncodingModel {
+  contentType: string;
+  readonly headers: Map<string, Header>;
+  style: SerializationStyle;
+  explode: boolean;
+  allowReserved: boolean;
+
+  constructor(parent: EncodingParent, contentType: string) {
+    super(parent);
+    this.contentType = contentType;
+    this.headers = new Map<string, Header>();
+    this.style = 'form';
+    this.explode = false;
+    this.allowReserved = false;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Example.ts
+++ b/packages/openapi-model/src/3.0.3/model/Example.ts
@@ -1,0 +1,28 @@
+import { BasicNode } from './BasicNode';
+
+import type { Components } from './Components';
+import type { Header } from './Header';
+import type { MediaType } from './MediaType';
+import type { Parameter } from './Parameter';
+import type { ExampleModel } from './types';
+import type { Nullable, URLString, JSONValue } from '@fresha/api-tools-core';
+
+export type ExampleParent = Components | MediaType | Parameter | Header;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#example-object
+ */
+export class Example extends BasicNode<ExampleParent> implements ExampleModel {
+  summary: Nullable<string>;
+  description: Nullable<string>;
+  value: JSONValue;
+  externalValue: Nullable<URLString>;
+
+  constructor(parent: ExampleParent) {
+    super(parent);
+    this.summary = null;
+    this.description = null;
+    this.value = null;
+    this.externalValue = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/ExternalDocumentation.ts
+++ b/packages/openapi-model/src/3.0.3/model/ExternalDocumentation.ts
@@ -1,0 +1,27 @@
+import { BasicNode } from './BasicNode';
+
+import type { OpenAPI } from './OpenAPI';
+import type { Operation } from './Operation';
+import type { Schema } from './Schema';
+import type { Tag } from './Tag';
+import type { ExternalDocumentationModel } from './types';
+import type { CommonMarkString, Nullable, URLString } from '@fresha/api-tools-core';
+
+export type ExternalDocumentationParent = OpenAPI | Operation | Schema | Tag;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#external-documentation-object
+ */
+export class ExternalDocumentation
+  extends BasicNode<ExternalDocumentationParent>
+  implements ExternalDocumentationModel
+{
+  url: URLString;
+  description: Nullable<CommonMarkString>;
+
+  constructor(parent: ExternalDocumentationParent, url: URLString) {
+    super(parent);
+    this.url = url;
+    this.description = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Header.ts
+++ b/packages/openapi-model/src/3.0.3/model/Header.ts
@@ -1,0 +1,42 @@
+import { BasicNode } from './BasicNode';
+
+import type { Components } from './Components';
+import type { Encoding } from './Encoding';
+import type { Example } from './Example';
+import type { MediaType } from './MediaType';
+import type { Response } from './Response';
+import type { Schema } from './Schema';
+import type { HeaderModel, MIMETypeString } from './types';
+import type { Nullable, JSONValue } from '@fresha/api-tools-core';
+
+export type HeaderParent = Components | Response | Encoding;
+
+export type SerializationStyle = 'simple';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#header-object
+ */
+export class Header extends BasicNode<HeaderParent> implements HeaderModel {
+  description: Nullable<string>;
+  required: boolean;
+  deprecated: boolean;
+  style: SerializationStyle;
+  explode: boolean;
+  schema: Nullable<Schema>;
+  example: JSONValue;
+  readonly examples: Map<string, Example>;
+  readonly content: Map<MIMETypeString, MediaType>;
+
+  constructor(parent: HeaderParent) {
+    super(parent);
+    this.description = null;
+    this.required = false;
+    this.deprecated = false;
+    this.style = 'simple';
+    this.explode = false;
+    this.schema = null;
+    this.example = null;
+    this.examples = new Map<string, Example>();
+    this.content = new Map<MIMETypeString, MediaType>();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Info.ts
+++ b/packages/openapi-model/src/3.0.3/model/Info.ts
@@ -1,0 +1,31 @@
+import { BasicNode } from './BasicNode';
+import { Contact } from './Contact';
+import { License } from './License';
+
+import type { OpenAPI } from './OpenAPI';
+import type { InfoModel } from './types';
+import type { CommonMarkString, Nullable, URLString, VersionString } from '@fresha/api-tools-core';
+
+export type InfoParent = OpenAPI;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#info-object
+ */
+export class Info extends BasicNode<InfoParent> implements InfoModel {
+  title: string;
+  description: Nullable<CommonMarkString>;
+  termsOfService: Nullable<URLString>;
+  readonly contact: Contact;
+  readonly license: License;
+  version: VersionString;
+
+  constructor(parent: InfoParent, title: string, version: VersionString) {
+    super(parent);
+    this.title = title;
+    this.description = null;
+    this.termsOfService = null;
+    this.contact = new Contact(this);
+    this.license = new License(this, 'UNLICENSED');
+    this.version = version;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/License.ts
+++ b/packages/openapi-model/src/3.0.3/model/License.ts
@@ -1,0 +1,21 @@
+import { BasicNode } from './BasicNode';
+
+import type { Info } from './Info';
+import type { LicenseModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type LicenseParent = Info;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#license-object
+ */
+export class License extends BasicNode<LicenseParent> implements LicenseModel {
+  name: string;
+  url: Nullable<string>;
+
+  constructor(parent: LicenseParent, name: string) {
+    super(parent);
+    this.name = name;
+    this.url = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Link.ts
+++ b/packages/openapi-model/src/3.0.3/model/Link.ts
@@ -1,0 +1,31 @@
+import { BasicNode } from './BasicNode';
+
+import type { Components } from './Components';
+import type { Response } from './Response';
+import type { Server } from './Server';
+import type { LinkModel } from './types';
+import type { Nullable, JSONValue } from '@fresha/api-tools-core';
+
+export type LinkParent = Components | Response;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#link-object
+ */
+export class Link extends BasicNode<LinkParent> implements LinkModel {
+  operationRef: Nullable<string>;
+  operationId: Nullable<string>;
+  readonly parameters: Map<string, JSONValue>;
+  requestBody: JSONValue;
+  description: Nullable<string>;
+  server: Nullable<Server>;
+
+  constructor(parent: LinkParent) {
+    super(parent);
+    this.operationRef = null;
+    this.operationId = null;
+    this.parameters = new Map<string, JSONValue>();
+    this.requestBody = null;
+    this.description = null;
+    this.server = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/MediaType.ts
+++ b/packages/openapi-model/src/3.0.3/model/MediaType.ts
@@ -1,0 +1,42 @@
+import { SchemaType } from '../types';
+
+import { BasicNode } from './BasicNode';
+import { Schema, SchemaFactory } from './Schema';
+
+import type { Encoding } from './Encoding';
+import type { Example } from './Example';
+import type { Parameter } from './Parameter';
+import type { RequestBody } from './RequestBody';
+import type { Response } from './Response';
+import type { MediaTypeModel } from './types';
+import type { Nullable, JSONValue } from '@fresha/api-tools-core';
+
+export type MediaTypeParent = Parameter | RequestBody | Response;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#media-type-object
+ */
+export class MediaType extends BasicNode<MediaTypeParent> implements MediaTypeModel {
+  schema: Nullable<Schema>;
+  example: JSONValue;
+  readonly examples: Map<string, Example>;
+  readonly encoding: Map<string, Encoding>;
+
+  constructor(parent: MediaTypeParent) {
+    super(parent);
+    this.schema = null;
+    this.example = null;
+    this.examples = new Map<string, Example>();
+    this.encoding = new Map<string, Encoding>();
+  }
+
+  setSchema(type: SchemaType): Schema {
+    const result = SchemaFactory.create(this, type) as Schema;
+    this.schema = result;
+    return result;
+  }
+
+  deleteSchema(): void {
+    this.schema = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthAuthorisationCodeFlow.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthAuthorisationCodeFlow.ts
@@ -1,0 +1,21 @@
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthAuthorizationCodeFlowModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export class OAuthAuthorisationCodeFlow
+  extends OAuthFlowBase
+  implements OAuthAuthorizationCodeFlowModel
+{
+  authorizationUrl: URLString;
+  tokenUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, authorizationUrl: URLString, tokenUrl: URLString) {
+    super(parent, 'authorizationCode');
+    this.authorizationUrl = authorizationUrl;
+    this.tokenUrl = tokenUrl;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthClientCredentialsFlow.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthClientCredentialsFlow.ts
@@ -1,0 +1,19 @@
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthClientCredentialsFlowModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export class OAuthClientCredentialsFlow
+  extends OAuthFlowBase
+  implements OAuthClientCredentialsFlowModel
+{
+  tokenUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, tokenUrl: URLString) {
+    super(parent, 'clientCredentials');
+    this.tokenUrl = tokenUrl;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.ts
@@ -1,0 +1,24 @@
+import { BasicNode } from '../BasicNode';
+
+import type { OAuthFlows } from './OAuthFlows';
+import type { URLString, Nullable } from '@fresha/api-tools-core';
+
+export type OAuthFlowType = 'implicit' | 'password' | 'clientCredentials' | 'authorizationCode';
+
+export type OAuthFlowParent = OAuthFlows;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export abstract class OAuthFlowBase extends BasicNode<OAuthFlowParent> {
+  readonly type: OAuthFlowType;
+  refreshUrl: Nullable<URLString>;
+  scopes: Map<string, string>;
+
+  constructor(parent: OAuthFlowParent, type: OAuthFlowType) {
+    super(parent);
+    this.type = type;
+    this.refreshUrl = null;
+    this.scopes = new Map<string, string>();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlows.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlows.ts
@@ -1,0 +1,29 @@
+import { BasicNode } from '../BasicNode';
+
+import type { OAuth2Scheme } from '../SecurityScheme/OAuth2Scheme';
+import type { OAuthFlowsModel } from '../types';
+import type { OAuthAuthorisationCodeFlow } from './OAuthAuthorisationCodeFlow';
+import type { OAuthClientCredentialsFlow } from './OAuthClientCredentialsFlow';
+import type { OAuthImplicitFlow } from './OAuthImplicitFlow';
+import type { OAuthPasswordFlow } from './OAuthPasswordFlow';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type OAuthFlowsParent = OAuth2Scheme;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flows-object
+ */
+export class OAuthFlows extends BasicNode<OAuthFlowsParent> implements OAuthFlowsModel {
+  implicit: Nullable<OAuthImplicitFlow>;
+  password: Nullable<OAuthPasswordFlow>;
+  clientCredentials: Nullable<OAuthClientCredentialsFlow>;
+  authorizationCode: Nullable<OAuthAuthorisationCodeFlow>;
+
+  constructor(parent: OAuthFlowsParent) {
+    super(parent);
+    this.implicit = null;
+    this.password = null;
+    this.clientCredentials = null;
+    this.authorizationCode = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthImplicitFlow.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthImplicitFlow.ts
@@ -1,0 +1,16 @@
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthImplicitFlowModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export class OAuthImplicitFlow extends OAuthFlowBase implements OAuthImplicitFlowModel {
+  authorizationUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, authorizationUrl: string) {
+    super(parent, 'implicit');
+    this.authorizationUrl = authorizationUrl;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthPasswordFlow.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthPasswordFlow.ts
@@ -1,0 +1,16 @@
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthPasswordFlowModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export class OAuthPasswordFlow extends OAuthFlowBase implements OAuthPasswordFlowModel {
+  tokenUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, tokenUrl: URLString) {
+    super(parent, 'password');
+    this.tokenUrl = tokenUrl;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/index.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/index.ts
@@ -1,0 +1,14 @@
+import type { OAuthAuthorisationCodeFlow } from './OAuthAuthorisationCodeFlow';
+import type { OAuthClientCredentialsFlow } from './OAuthClientCredentialsFlow';
+import type { OAuthImplicitFlow } from './OAuthImplicitFlow';
+import type { OAuthPasswordFlow } from './OAuthPasswordFlow';
+
+export type OAuthFlow =
+  | OAuthAuthorisationCodeFlow
+  | OAuthClientCredentialsFlow
+  | OAuthPasswordFlow
+  | OAuthImplicitFlow;
+
+export type { OAuthFlowType, OAuthFlowParent } from './OAuthFlowBase';
+
+export { OAuthFlows, OAuthFlowsParent } from './OAuthFlows';

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
@@ -1,0 +1,10 @@
+import { OpenAPI } from './OpenAPI';
+
+test('ownership', () => {
+  const openapi = new OpenAPI('example', '0.1.0');
+  expect(openapi.root).toBe(openapi);
+
+  expect(openapi.info.parent).toBe(openapi);
+  expect(openapi.info.contact.parent).toBe(openapi.info);
+  expect(openapi.info.license.parent).toBe(openapi.info);
+});

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -1,0 +1,131 @@
+import { Components } from './Components';
+import { ExternalDocumentation } from './ExternalDocumentation';
+import { Info } from './Info';
+import { PathItem } from './PathItem';
+import { Paths } from './Paths';
+import { SecurityRequirement } from './SecurityRequirement';
+import { Server as ServerImpl } from './Server';
+import { Tag } from './Tag';
+
+import type {
+  OpenApiVersion,
+  OpenAPIModel,
+  ParametrisedURLString,
+  ServerModel,
+  PathItemModel,
+  TagModel,
+  SpecificationExtensionsModel,
+} from './types';
+import type { CommonMarkString, Nullable, VersionString, JSONValue } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#openapi-object
+ */
+export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
+  readonly openapi: OpenApiVersion;
+  info: Info;
+  servers: ServerImpl[];
+  readonly paths: Paths;
+  readonly components: Components;
+  security: Nullable<SecurityRequirement[]>;
+  tags: Tag[];
+  externalDocs: Nullable<ExternalDocumentation>;
+  readonly extensions: Map<string, JSONValue>;
+
+  constructor(title: string, version: VersionString) {
+    this.openapi = '3.0.3';
+    this.info = new Info(this, title, version);
+    this.servers = [];
+    this.paths = new Paths(this);
+    this.components = new Components(this);
+    this.security = null;
+    this.tags = [];
+    this.externalDocs = null;
+    this.extensions = new Map<string, JSONValue>();
+  }
+
+  get root(): OpenAPI {
+    return this;
+  }
+
+  setExtension(key: string, value: JSONValue): void {
+    this.extensions.set(key, value);
+  }
+
+  deleteExtension(key: string): void {
+    this.extensions.delete(key);
+  }
+
+  clearExtensions(): void {
+    this.extensions.clear();
+  }
+
+  addServer(
+    url: ParametrisedURLString,
+    variableDefaults?: Record<string, string>,
+    description?: CommonMarkString,
+  ): ServerModel {
+    if (this.servers.find(server => server.url === url)) {
+      throw new Error(`Duplicate server URL ${url}`);
+    }
+
+    const server = new ServerImpl(this, url, variableDefaults);
+    if (description) {
+      server.description = description;
+    }
+    this.servers.push(server);
+    return server;
+  }
+
+  removeServerAt(index: number): void {
+    this.servers.splice(index, 1);
+  }
+
+  clearServers(): void {
+    this.servers.splice(0, this.servers.length);
+  }
+
+  setPathItem(url: ParametrisedURLString): PathItemModel {
+    if (this.paths.items.has(url)) {
+      throw new Error(`Duplicate path item ${url}`);
+    }
+    const pathItem = new PathItem(this.paths);
+    this.paths.items.set(url, pathItem);
+    return pathItem;
+  }
+
+  deletePathItem(url: ParametrisedURLString): void {
+    this.paths.delete(url);
+  }
+
+  clearPathItems(): void {
+    this.paths.clear();
+  }
+
+  addTag(name: string): TagModel {
+    if (this.tags.find(tag => tag.name === name)) {
+      throw new Error(`Duplicate tag ${name}`);
+    }
+    const tag = new Tag(this, name);
+    this.tags.push(tag);
+    return tag;
+  }
+
+  deleteTag(name: string): void {
+    const index = this.tags.findIndex(tag => tag.name === name);
+    if (index >= 0) {
+      this.deleteTagAt(index);
+    }
+  }
+
+  deleteTagAt(index: number): void {
+    this.tags.splice(index, 1);
+  }
+
+  clearTags(): void {
+    this.tags.splice(0, this.tags.length);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  dispose(): void {}
+}

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
@@ -1,0 +1,1630 @@
+import { OpenAPIReader } from './OpenAPIReader';
+import { Schema } from './Schema';
+import { SchemaModel } from './types';
+
+import type { JSONValue } from '@fresha/api-tools-core';
+
+test('barebones', () => {
+  const reader = new OpenAPIReader();
+  const openapi = reader.parse({
+    openapi: '3.0.3',
+    info: {
+      title: 'Barebones',
+      version: '1.2.3',
+    },
+    paths: {},
+    components: {},
+  });
+
+  expect(openapi.info.title).toBe('Barebones');
+  expect(openapi.info.version).toBe('1.2.3');
+  expect(openapi.paths.size).toBe(0);
+  expect(openapi.components.isEmpty()).toBeTruthy();
+});
+
+describe('SchemaModel', () => {
+  test('sets correct default schema attributes', () => {
+    const reader = new OpenAPIReader();
+    const openapi = reader.parse({
+      openapi: '3.0.3',
+      info: {
+        title: 'Components.schemas test',
+        version: '0.1.0',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          EmptySchema: {},
+        },
+      },
+    });
+
+    expect(openapi.components.schemas).toHaveProperty('size', 1);
+
+    const emptySchema = openapi.components.schemas.get('EmptySchema');
+    expect(emptySchema).toHaveProperty('title', null);
+    expect(emptySchema).toHaveProperty('multipleOf', null);
+    expect(emptySchema).toHaveProperty('maximum', null);
+    expect(emptySchema).toHaveProperty('exclusiveMaximum', false);
+    expect(emptySchema).toHaveProperty('minimum', null);
+    expect(emptySchema).toHaveProperty('exclusiveMinimum', false);
+    expect(emptySchema).toHaveProperty('minLength', null);
+    expect(emptySchema).toHaveProperty('maxLength', null);
+    expect(emptySchema).toHaveProperty('pattern', null);
+    expect(emptySchema).toHaveProperty('minItems', null);
+    expect(emptySchema).toHaveProperty('maxItems', null);
+    expect(emptySchema).toHaveProperty('uniqueItems', false);
+    expect(emptySchema).toHaveProperty('minProperties', null);
+    expect(emptySchema).toHaveProperty('maxProperties', null);
+    expect(emptySchema).toHaveProperty('required', new Set<string>());
+    expect(emptySchema).toHaveProperty('enum', null);
+    expect(emptySchema).toHaveProperty('type', null);
+    expect(emptySchema).toHaveProperty('allOf', null);
+    expect(emptySchema).toHaveProperty('oneOf', null);
+    expect(emptySchema).toHaveProperty('anyOf', null);
+    expect(emptySchema).toHaveProperty('not', null);
+    expect(emptySchema).toHaveProperty('items', null);
+    expect(emptySchema).toHaveProperty('properties', new Map<string, SchemaModel>());
+    expect(emptySchema).toHaveProperty('additionalProperties', true);
+    expect(emptySchema).toHaveProperty('description', null);
+    expect(emptySchema).toHaveProperty('format', null);
+    expect(emptySchema).toHaveProperty('default', null);
+    expect(emptySchema).toHaveProperty('nullable', false);
+    expect(emptySchema).toHaveProperty('discriminator', null);
+    expect(emptySchema).toHaveProperty('readOnly', false);
+    expect(emptySchema).toHaveProperty('writeOnly', false);
+    expect(emptySchema).toHaveProperty('xml', null);
+    expect(emptySchema).toHaveProperty('externalDocs', null);
+    expect(emptySchema).toHaveProperty('example', null);
+    expect(emptySchema).toHaveProperty('deprecated', false);
+  });
+
+  test('reads schema attributes', () => {
+    const reader = new OpenAPIReader();
+    const openapi = reader.parse({
+      openapi: '3.0.3',
+      info: {
+        title: 'Components.schemas test',
+        version: '0.1.0',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          ErrorMessage: {
+            'x-prop-1': 'extension property 1',
+            'x-prop-2': ['extension property 2'],
+            title: 'error message schema',
+            multipleOf: 4,
+            maximum: 100,
+            exclusiveMaximum: true,
+            minimum: 10,
+            exclusiveMinimum: false,
+            minLength: 5,
+            maxLength: 25,
+            pattern: '*',
+            maxItems: 10,
+            minItems: 1,
+            uniqueItems: true,
+            minProperties: 2,
+            maxProperties: 4,
+            required: ['x', 'y'],
+            enum: [1, '12', false],
+            type: 'string',
+            allOf: [{ type: 'object' }, { type: 'integer' }],
+            oneOf: [{ type: 'object' }, { type: 'boolean' }],
+            anyOf: [{ type: 'number' }],
+            not: { type: 'array' },
+            items: { type: 'integer' },
+            properties: {
+              x: { type: 'boolean' },
+              y: {},
+              z: {},
+            },
+            additionalProperties: false,
+            description: '# This **is** markdown text',
+            format: 'int64',
+            default: 138472,
+            nullable: true,
+            discriminator: { propertyName: 'x' },
+            readOnly: true,
+            writeOnly: true,
+            xml: {},
+            externalDocs: { url: 'https://docs.example.com' },
+            example: 12,
+            deprecated: true,
+          },
+        },
+      },
+    });
+
+    expect(openapi.components.schemas).toHaveProperty('size', 1);
+
+    const errorMessageSchema = openapi.components.schemas.get('ErrorMessage');
+
+    expect(errorMessageSchema).toHaveProperty('root', openapi);
+    expect(errorMessageSchema).toHaveProperty('parent', openapi.components);
+    expect(errorMessageSchema).toHaveProperty(
+      'extensions',
+      new Map<string, JSONValue>([
+        ['prop-1', 'extension property 1'],
+        ['prop-2', ['extension property 2']],
+      ]),
+    );
+    expect(errorMessageSchema).toHaveProperty('title', 'error message schema');
+    expect(errorMessageSchema).toHaveProperty('multipleOf', 4);
+    expect(errorMessageSchema).toHaveProperty('maximum', 100);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMaximum', true);
+    expect(errorMessageSchema).toHaveProperty('minimum', 10);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMinimum', false);
+    expect(errorMessageSchema).toHaveProperty('minLength', 5);
+    expect(errorMessageSchema).toHaveProperty('maxLength', 25);
+    expect(errorMessageSchema).toHaveProperty('pattern', '*');
+    expect(errorMessageSchema).toHaveProperty('minItems', 1);
+    expect(errorMessageSchema).toHaveProperty('maxItems', 10);
+    expect(errorMessageSchema).toHaveProperty('uniqueItems', true);
+    expect(errorMessageSchema).toHaveProperty('minProperties', 2);
+    expect(errorMessageSchema).toHaveProperty('maxProperties', 4);
+    expect(errorMessageSchema).toHaveProperty('required', new Set<string>(['x', 'y']));
+    expect(errorMessageSchema).toHaveProperty('enum', [1, '12', false]);
+    expect(errorMessageSchema).toHaveProperty('type', 'string');
+
+    const allOfSchemas = errorMessageSchema?.allOf;
+    expect(allOfSchemas?.length).toBe(2);
+    expect(allOfSchemas?.[0]).toHaveProperty('root', openapi);
+    expect(allOfSchemas?.[0]).toHaveProperty('parent', errorMessageSchema);
+    expect(allOfSchemas?.[0]).toHaveProperty('type', 'object');
+    expect(allOfSchemas?.[1]).toHaveProperty('type', 'integer');
+
+    const oneOfSchemas = errorMessageSchema?.oneOf;
+    expect(oneOfSchemas).toHaveProperty('length', 2);
+    expect(oneOfSchemas?.[0]).toHaveProperty('type', 'object');
+    expect(oneOfSchemas?.[1]).toHaveProperty('type', 'boolean');
+
+    const anyOfSchemas = errorMessageSchema?.anyOf;
+    expect(anyOfSchemas?.length).toBe(1);
+    expect(anyOfSchemas?.[0]).toHaveProperty('type', 'number');
+
+    expect(errorMessageSchema?.not).toHaveProperty('type', 'array');
+
+    const errorMessageItems = errorMessageSchema?.items;
+    expect(errorMessageItems).toHaveProperty('root', openapi);
+    expect(errorMessageItems).toHaveProperty('parent', errorMessageSchema);
+    expect(errorMessageItems).toHaveProperty('type', 'integer');
+
+    expect(errorMessageSchema?.properties.size).toBe(3);
+
+    const errorMessagePropertyX = errorMessageSchema?.properties.get('x');
+    expect(errorMessagePropertyX).toHaveProperty('root', openapi);
+    expect(errorMessagePropertyX).toHaveProperty('parent', errorMessageSchema);
+    expect(errorMessagePropertyX).toHaveProperty('type', 'boolean');
+
+    const errorMessagePropertyY = errorMessageSchema?.properties.get('y');
+    expect(errorMessagePropertyY).toHaveProperty('root', openapi);
+    expect(errorMessagePropertyY).toHaveProperty('parent', errorMessageSchema);
+
+    const errorMessagePropertyZ = errorMessageSchema?.properties.get('z');
+    expect(errorMessagePropertyZ).toHaveProperty('root', openapi);
+    expect(errorMessagePropertyZ).toHaveProperty('parent', errorMessageSchema);
+
+    expect(errorMessageSchema).toHaveProperty('additionalProperties', false);
+
+    expect(errorMessageSchema).toHaveProperty('description', '# This **is** markdown text');
+    expect(errorMessageSchema).toHaveProperty('format', 'int64');
+    expect(errorMessageSchema).toHaveProperty('default', 138472);
+    expect(errorMessageSchema).toHaveProperty('nullable', true);
+
+    const errorMessageDiscriminator = errorMessageSchema?.discriminator;
+    expect(errorMessageDiscriminator).toHaveProperty('root', openapi);
+    expect(errorMessageDiscriminator).toHaveProperty('parent', errorMessageSchema);
+
+    expect(errorMessageSchema).toHaveProperty('readOnly', true);
+    expect(errorMessageSchema).toHaveProperty('writeOnly', true);
+
+    const errorMessageXML = errorMessageSchema?.xml;
+    expect(errorMessageXML).toHaveProperty('root', openapi);
+    expect(errorMessageXML).toHaveProperty('parent', errorMessageSchema);
+
+    const errorMessageDocs = errorMessageSchema?.externalDocs;
+    expect(errorMessageDocs).toHaveProperty('root', openapi);
+    expect(errorMessageDocs).toHaveProperty('parent', errorMessageSchema);
+
+    expect(errorMessageSchema).toHaveProperty('example', 12);
+    expect(errorMessageSchema).toHaveProperty('deprecated', true);
+  });
+});
+
+describe('ComponentsModel', () => {
+  test('schema references are read and resolved', () => {
+    const reader = new OpenAPIReader();
+    const openapi = reader.parse({
+      openapi: '3.0.3',
+      info: {
+        title: 'Components.schemas test',
+        version: '0.1.0',
+      },
+      paths: {},
+      components: {
+        schemas: {
+          ErrorMessage: {
+            type: 'string',
+          },
+          Error: {
+            type: 'object',
+            properties: {
+              message: { $ref: '#/components/schemas/ErrorMessage' },
+              code: {
+                type: 'integer',
+              },
+            },
+          },
+          ErrorList: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Error' },
+          },
+        },
+      },
+    });
+
+    expect(openapi.components.schemas.size).toBe(3);
+
+    const errorMessageSchema = openapi.components.schemas.get('ErrorMessage');
+
+    expect(errorMessageSchema).toHaveProperty('root', openapi);
+    expect(errorMessageSchema).toHaveProperty('parent', openapi.components);
+
+    const errorSchema = openapi.components.schemas.get('Error');
+    expect(errorSchema).toHaveProperty('root', openapi);
+    expect(errorSchema).toHaveProperty('parent', openapi.components);
+    expect(errorSchema?.properties.get('message')).toBe(errorMessageSchema);
+
+    const errorCodeSchema = errorSchema?.properties.get('code') as Schema;
+    expect(errorCodeSchema).toBeTruthy();
+    expect(errorCodeSchema).toHaveProperty('root', openapi);
+    expect(errorCodeSchema).toHaveProperty('parent', errorSchema);
+
+    const errorListSchema = openapi.components.schemas.get('ErrorList');
+    expect(errorListSchema).toHaveProperty('root', openapi);
+    expect(errorListSchema).toHaveProperty('parent', openapi.components);
+  });
+});
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import ApiKeyScheme from './ApiKeyScheme';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON throws without required data', () => {
+//   expect(() => ApiKeyScheme.fromJSON({}, parent));
+//   expect(() => ApiKeyScheme.fromJSON({ type: 'apiKey' }, parent));
+//   expect(() => ApiKeyScheme.fromJSON({ type: 'apiKey', description: 'scheme' }, parent));
+// });
+
+// it("fromJSON throws if the type field has value other than 'http'", () => {
+//   expect(() => ApiKeyScheme.fromJSON({ type: 'http', name: 'x', in: 'cookie' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     type: 'apiKey',
+//     description: 'security',
+//     name: 'session_cookie',
+//     in: 'cookie',
+//     'x-one': 1,
+//   };
+//   const scheme = ApiKeyScheme.fromJSON(json, parent);
+//   expect(scheme.type).toBe('apiKey');
+//   expect(scheme.toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import OAuth2Scheme from './OAuth2Scheme';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON throws without required data', () => {
+//   expect(() => OAuth2Scheme.fromJSON({}, parent));
+//   expect(() => OAuth2Scheme.fromJSON({ type: 'oauth2' }, parent));
+//   expect(() => OAuth2Scheme.fromJSON({ type: 'oauth2', description: 'scheme' }, parent));
+// });
+
+// it("fromJSON throws if the type field has value other than 'http'", () => {
+//   expect(() => OAuth2Scheme.fromJSON({ type: 'apiKey', flows: {} }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     type: 'oauth2',
+//     description: 'security',
+//     flows: {
+//       implicit: {
+//         authorizationUrl: 'http://www.example.com/auth',
+//         'x-flow': 'flow2',
+//       },
+//     },
+//     'x-one': 1,
+//   };
+//   const scheme = OAuth2Scheme.fromJSON(json, parent);
+//   expect(scheme.type).toBe('oauth2');
+//   expect(scheme.toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import OpenIdConnectScheme from './OpenIdConnectScheme';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON throws without required data', () => {
+//   expect(() => OpenIdConnectScheme.fromJSON({}, parent));
+//   expect(() => OpenIdConnectScheme.fromJSON({ type: 'opeenIdConnect' }, parent));
+//   expect(() =>
+//     OpenIdConnectScheme.fromJSON({ type: 'opeenIdConnect', description: 'scheme' }, parent),
+//   );
+// });
+
+// it("fromJSON throws if the type field has value other than 'http'", () => {
+//   expect(() =>
+//     OpenIdConnectScheme.fromJSON({ type: 'http', name: 'x', in: 'cookie' }, parent),
+//   ).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     type: 'openIdConnect',
+//     description: 'security',
+//     openIdConnectUrl: 'http://openid.example.com',
+//     'x-one': 1,
+//   };
+//   const scheme = OpenIdConnectScheme.fromJSON(json, parent);
+//   expect(scheme.type).toBe('openIdConnect');
+//   expect(scheme.toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+// import { JSONObject } from '../jsonUtils';
+
+// import SecurityScheme from '.';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it.each([
+//   ['apiKey', { type: 'apiKey', name: 'sessionId', in: 'cookie' }],
+//   ['http', { type: 'http', scheme: 'bearer' }],
+//   ['oauth2', { type: 'oauth2', flows: {} }],
+//   [
+//     'openIdConnect',
+//     {
+//       type: 'openIdConnect',
+//       openIdConnectUrl: 'http://www.example.com/openid',
+//     },
+//   ],
+// ] as [string, JSONObject][])('recognizes %s security scheme type', (_name, json) => {
+//   expect(SecurityScheme.fromJSON(json, parent)).not.toBeNull();
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import HttpScheme from './HttpScheme';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON throws without required data', () => {
+//   expect(() => HttpScheme.fromJSON({}, parent));
+//   expect(() => HttpScheme.fromJSON({ type: 'http' }, parent));
+//   expect(() => HttpScheme.fromJSON({ type: 'http', description: 'scheme' }, parent));
+// });
+
+// it("fromJSON throws if the type field has value other than 'http'", () => {
+//   expect(() => HttpScheme.fromJSON({ type: 'apiKey', name: 'x', in: 'cookie' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     type: 'http',
+//     description: 'security',
+//     scheme: 'bearer',
+//     bearerFormat: 'cookie',
+//     'x-one': 1,
+//   };
+//   const scheme = HttpScheme.fromJSON(json, parent);
+//   expect(scheme.type).toBe('http');
+//   expect(scheme.toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+// import { JSONObject } from '../jsonUtils';
+
+// import Schema from '.';
+
+// let components: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Schema.test', '0.1.0');
+//   components = openapi.components;
+// });
+
+// it('fromJSON works', () => {
+//   const schema = Schema.fromJSON(
+//     {
+//       anyOf: [
+//         { type: 'boolean' },
+//         { type: 'integer' },
+//         { type: 'number' },
+//         {
+//           allOf: [
+//             { not: { type: 'string' } },
+//             { oneOf: [{ type: 'array', items: { type: 'object' } }] },
+//           ],
+//         },
+//       ],
+//     },
+//     components,
+//   );
+
+//   expect(schema).not.toBeNull();
+//   expect(
+//     (((schema as unknown as JSONObject).anyOf as JSONObject[])[3].allOf as JSONObject[])[0].not,
+//   ).not.toBeNull();
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import { ParserFunc } from './Schema';
+// import BooleanSchema from './BooleanSchema';
+
+// let components: Components;
+// let fromJSON: ParserFunc;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('BooleanSchema.test', '0.1.0');
+//   components = openapi.components;
+//   fromJSON = jest.fn();
+// });
+
+// describe('schemaFromJSON works', () => {
+//   it('returns false for non-boolean schemas', () => {
+//     expect(BooleanSchema.schemaFromJSON({ type: 'number' }, components, fromJSON)).toBeFalsy();
+//   });
+
+//   it('parses valid schema', () => {
+//     expect(BooleanSchema.schemaFromJSON({ type: 'boolean' }, components, fromJSON)).toBeInstanceOf(
+//       BooleanSchema,
+//     );
+//   });
+// });
+
+// it('toJSON works', () => {
+//   const schema = new BooleanSchema(components);
+//   expect(schema.toJSON()).toEqual({ type: 'boolean' });
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import QueryParameter from './QueryParameter';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('QueryParameter.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON must throw if in or name is missing', () => {
+//   expect(() => QueryParameter.fromJSON({}, parent)).toThrow();
+//   expect(() => QueryParameter.fromJSON({ name: 'param' }, parent)).toThrow();
+//   expect(() => QueryParameter.fromJSON({ in: 'query' }, parent)).toThrow();
+// });
+
+// it('fromJSON must throw if the in attribute has wong value', () => {
+//   expect(() => QueryParameter.fromJSON({ in: 'cookie', name: 'param' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     in: 'query',
+//     name: 'queryParam',
+//     required: true,
+//     style: 'deepObject',
+//     description: 'Lalala',
+//     allowReserved: true,
+//   };
+//   expect(QueryParameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import PathParameter from './PathParameter';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('PathParameter.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON must throw if in or name is missing', () => {
+//   expect(() => PathParameter.fromJSON({}, parent)).toThrow();
+//   expect(() => PathParameter.fromJSON({ name: 'param' }, parent)).toThrow();
+//   expect(() => PathParameter.fromJSON({ in: 'path' }, parent)).toThrow();
+// });
+
+// it('fromJSON must throw if the in attribute has wong value', () => {
+//   expect(() => PathParameter.fromJSON({ in: 'cookie', name: 'param' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     in: 'path',
+//     name: 'pathParam',
+//     style: 'label',
+//     description: 'Lalala',
+//   };
+//   expect(PathParameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import Parameter from '.';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Parameter.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON should throw if in is missing or has wrong value', () => {
+//   expect(() => Parameter.fromJSON({}, parent)).toThrow();
+//   expect(() => Parameter.fromJSON({ name: 'someParam' }, parent)).toThrow();
+//   expect(() => Parameter.fromJSON({ in: 'x', name: 'p' }, parent)).toThrow();
+// });
+
+// it('fromJSON should throw if both the schema and content are given', () => {
+//   expect(() =>
+//     Parameter.fromJSON(
+//       {
+//         in: 'path',
+//         name: 'pathParam',
+//         schema: { type: 'boolean' },
+//         content: {
+//           'application/json': {
+//             schema: { type: 'boolean' },
+//           },
+//         },
+//       },
+//       parent,
+//     ),
+//   ).toThrow();
+// });
+
+// it('fromJSON should throw if both example and examples are given', () => {
+//   expect(() => {
+//     Parameter.fromJSON(
+//       {
+//         in: 'cookie',
+//         name: 'cookieParam',
+//         example: true,
+//         examples: {
+//           'application/json': {
+//             example: true,
+//           },
+//         },
+//       },
+//       parent,
+//     );
+//   }).toThrow();
+// });
+
+// it.each([
+//   ['cookie', { in: 'cookie', name: 'cookieParam' }],
+//   ['header', { in: 'header', name: 'headerParam' }],
+//   ['path', { in: 'path', name: 'pathParam' }],
+//   ['query', { in: 'query', name: 'queryParam' }],
+// ])('fromJSON should parse parameter of type %s', (_type, json) => {
+//   expect(Parameter.fromJSON(json, parent)).not.toBeNull();
+// });
+
+// it('fromJSON + toJSON should be reversible with style + scheme', () => {
+//   const json = {
+//     in: 'cookie',
+//     name: 'cookieParam',
+//     required: true,
+//     style: 'spaceDelimited',
+//     description: 'Lalala',
+//     explode: true,
+//     deprecated: true,
+//     schema: {
+//       type: 'boolean',
+//       nullable: true,
+//     },
+//     example: true,
+//   };
+//   expect(Parameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// it('fromJSON + toJSON should be reversible with style + scheme, and a single example', () => {
+//   const json = {
+//     in: 'query',
+//     name: 'queryParam',
+//     required: true,
+//     style: 'spaceDelimited',
+//     description: 'Lalala',
+//     explode: true,
+//     deprecated: true,
+//     schema: {
+//       type: 'boolean',
+//       nullable: true,
+//     },
+//     example: true,
+//   };
+//   expect(Parameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// it('fromJSON + toJSON should be reversible with content, and multiple examples', () => {
+//   const json = {
+//     in: 'path',
+//     name: 'pathParam',
+//     content: {
+//       'application/json': {
+//         schema: {
+//           type: 'array',
+//           items: {
+//             type: 'number',
+//             nullable: true,
+//           },
+//         },
+//       },
+//     },
+//     examples: {
+//       'application/json': {
+//         summary: 'json1',
+//         description: 'JSON example',
+//         value: [1, 2, 3],
+//       },
+//     },
+//   };
+//   expect(Parameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// -------------------------------------------------------------------------------------------------------------------------
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import HeaderParameter from './HeaderParameter';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('SecurityScheme.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON must throw if in or name is missing', () => {
+//   expect(() => HeaderParameter.fromJSON({}, parent)).toThrow();
+//   expect(() => HeaderParameter.fromJSON({ name: 'param' }, parent)).toThrow();
+//   expect(() => HeaderParameter.fromJSON({ in: 'header' }, parent)).toThrow();
+// });
+
+// it('fromJSON must throw if the in attribute has wong value', () => {
+//   expect(() => HeaderParameter.fromJSON({ in: 'cookie', name: 'param' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     in: 'header',
+//     name: 'headerParam',
+//     required: true,
+//     description: 'Lalala',
+//   };
+//   expect(HeaderParameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// -------------------------------------------------------------------------------------------------------------------------
+
+// import OpenAPI from '../OpenAPI';
+// import Components from '../Components';
+
+// import CookieParameter from './CookieParameter';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('CookieParameter.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON must throw if in or name is missing', () => {
+//   expect(() => CookieParameter.fromJSON({}, parent)).toThrow();
+//   expect(() => CookieParameter.fromJSON({ name: 'param' }, parent)).toThrow();
+//   expect(() => CookieParameter.fromJSON({ in: 'cookie' }, parent)).toThrow();
+// });
+
+// it('fromJSON must throw if the in attribute has wong value', () => {
+//   expect(() => CookieParameter.fromJSON({ in: 'path', name: 'param' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     in: 'cookie',
+//     name: 'cookieParam',
+//     required: true,
+//     style: 'spaceDelimited',
+//     description: 'Lalala',
+//     'x-ext': 'absolutely awesome',
+//   };
+//   expect(CookieParameter.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// -------------------------------------------------------------------------------------------------------------------------
+
+// import SecurityScheme from '../SecurityScheme';
+// import OpenAPI from '../OpenAPI';
+// import OAuth2Scheme from '../SecurityScheme/OAuth2Scheme';
+// import { JSONObject } from '../jsonUtils';
+
+// import OAuthFlow, { OAuthFlowType } from '.';
+
+// let parent: SecurityScheme;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('OAuthFlow.test', '0.0.1');
+//   parent = new OAuth2Scheme(openapi.components);
+// });
+
+// it.each([
+//   [
+//     'implicit',
+//     {
+//       authorizationUrl: 'http://example.com/authorizationUrl',
+//     },
+//   ],
+//   [
+//     'password',
+//     {
+//       tokenUrl: 'http://example.com/tokenUrl',
+//     },
+//   ],
+//   [
+//     'clientCredentials',
+//     {
+//       tokenUrl: 'http://example.com/tokenUrl',
+//     },
+//   ],
+//   [
+//     'authorizationCode',
+//     {
+//       authorizationUrl: 'http://example.com/authorizationUrl',
+//       tokenUrl: 'http://example.com/tokenUrl',
+//     },
+//   ],
+// ] as [string, JSONObject][])('fromJSON can parse OAuth flow of type %s', (type, json) => {
+//   expect(OAuthFlow.fromJSON(json, type as OAuthFlowType, parent).toJSON()).toEqual(json);
+// });
+
+// -------------------------------------------------------------------------------------------------------------------------
+
+// import { JSONObject } from './jsonUtils';
+// import OpenAPI from './OpenAPI';
+// import { serverVariableFromJSON, tagFromJSON } from './load';
+// import Server from './Server';
+
+// test('load', () => {
+//   expect(1).toBe(1);
+// });
+
+// describe('ServerVariable', () => {
+//   let server: Server;
+
+//   beforeEach(() => {
+//     const openapi = new OpenAPI('ServerVariable.test', '0.0.1');
+//     server = new Server(openapi, 'http://api.example.com');
+//   });
+
+//   it('fromJSON throws if required data is missing', () => {
+//     expect(() => serverVariableFromJSON({}, server)).toThrow();
+//     expect(() => serverVariableFromJSON({ enum: ['1'] }, server)).toThrow();
+//   });
+
+//   // it('fromJSON + toJSON, non-enumerable variable', () => {
+//   //   const json = {
+//   //     default: 'v1',
+//   //     enum: [],
+//   //     'x-one': 1,
+//   //   };
+//   //   const serverVariable = serverVariableFromJSON(json, server);
+//   //   expect(serverVariable.description).toBeNull();
+//   //   expect(serverVariable.enum).toBeNull();
+//   //   expect(serverVariable.toJSON()).toEqual({ default: 'v1', 'x-one': 1 });
+//   // });
+
+//   // it('fromJSON + toJSON, all data present', () => {
+//   //   const json = {
+//   //     default: 'v1',
+//   //     description: 'API versions',
+//   //     enum: ['v1', 'v1.1', 'v2'],
+//   //     'x-two': 2,
+//   //   };
+//   //   expect(serverVariableFromJSON(json, server).toJSON()).toEqual(json);
+//   // });
+// });
+
+// describe('Tag', () => {
+//   let parent: OpenAPI;
+
+//   beforeEach(() => {
+//     parent = new OpenAPI('Tag.test', '0.0.1');
+//   });
+
+//   it('fromJSON with missing required data should throw', () => {
+//     expect(() => tagFromJSON(null as unknown as JSONObject, parent)).toThrow();
+//     expect(() => tagFromJSON({ description: 'tag' }, parent)).toThrow();
+//   });
+
+//   it('fromJSON + toJSON with only required data', () => {
+//     const json = { name: 'example' };
+//     const tag = tagFromJSON(json, parent);
+//     expect(tag.description).toBeNull();
+//     expect(tag.externalDocs).toBeNull();
+//     // expect(tag.toJSON()).toEqual(json);
+//   });
+
+//   // it('fromJSON + toJSON with all data', () => {
+//   //   const json = {
+//   //     name: 'new',
+//   //     description: 'a new tag',
+//   //     externalDocs: {
+//   //       url: 'http://www.example.com/docs',
+//   //       description: 'description',
+//   //     },
+//   //     'x-other': true,
+//   //   };
+//   //   expect(tagFromJSON(json, parent).toJSON()).toEqual(json);
+//   // });
+// });
+
+// import Components from './Components';
+// import OpenAPI from './OpenAPI';
+
+// let parent: OpenAPI;
+
+// beforeEach(() => {
+//   parent = new OpenAPI('Components.test', '0.0.1');
+// });
+
+// it('toJSON returns null if the components is empty', () => {
+//   const components = new Components(parent);
+//   expect(components.toJSON()).toBeNull();
+// });
+
+// it('fromJSON + toJSON is reversible', () => {
+//   const json = {
+//     schemas: {
+//       one: { type: 'string' },
+//       two: { type: 'object' },
+//     },
+//     responses: {
+//       resp1: {
+//         description: 'response 1',
+//       },
+//       resp2: {
+//         description: 'resp 2',
+//       },
+//     },
+//     parameters: {
+//       param1: { name: 'param1', in: 'path' },
+//       param2: { name: 'param2', in: 'query' },
+//     },
+//   };
+//   expect(Components.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import Contact from './Contact';
+// import Info from './Info';
+// import { JSONObject } from './jsonUtils';
+// import OpenAPI from './OpenAPI';
+
+// let info: Info;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('test', '1.0.0');
+//   info = openapi.info;
+// });
+
+// it('fromJSON', () => {
+//   expect(Contact.fromJSON(null as unknown as JSONObject, info)).toBeNull();
+//   expect(Contact.fromJSON({}, info)).toBeNull();
+
+//   const contact = Contact.fromJSON(
+//     { name: 'A', email: 'b@x.com', url: 'http://example.com' },
+//     info,
+//   );
+//   expect(contact?.name).toBe('A');
+//   expect(contact?.email).toBe('b@x.com');
+//   expect(contact?.url).toBe('http://example.com');
+// });
+
+// it('toJSON', () => {
+//   const contact = new Contact(info);
+//   expect(contact.toJSON()).toStrictEqual({});
+// });
+
+// it('fromJSON + toJSON - all fields', () => {
+//   const contactJson = {
+//     name: 'AA',
+//     email: 'user@example.com',
+//     url: 'http://example.com',
+//   };
+//   expect(Contact.fromJSON(contactJson, info)?.toJSON()).toEqual(contactJson);
+// });
+
+// import Encoding from './Encoding';
+// import MediaType from './MediaType';
+// import OpenAPI from './OpenAPI';
+// import RequestBody from './RequestBody';
+
+// let parent: MediaType;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Encoding.test', '0.0.1');
+//   const requestBody = new RequestBody(openapi.components);
+//   parent = new MediaType(requestBody);
+// });
+
+// it('fromJSON throws if the contentType attribute is missing', () => {
+//   expect(() => Encoding.fromJSON({}, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON are reversible', () => {
+//   const json = {
+//     contentType: 'application/json',
+//     headers: {
+//       'x-limit': {},
+//       'x-threshold': {},
+//     },
+//     style: 'deepObject',
+//     explode: true,
+//     allowReserved: true,
+//   };
+//   expect(Encoding.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from './OpenAPI';
+// import Components from './Components';
+// import Example from './Example';
+// import { JSONValue } from './jsonUtils';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Example.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON should throw if value and externalValue are supplied', () => {
+//   expect(() =>
+//     Example.fromJSON(
+//       {
+//         value: 1,
+//         externalValue: 'http://www.example.com',
+//       },
+//       parent,
+//     ),
+//   ).toThrow();
+// });
+
+// it('fromJSON + toJSON with all the data should give the same value as input', () => {
+//   const json = {
+//     summary: 'example',
+//     description: 'description',
+//     value: [{ a: 1 }, { b: 2 }] as JSONValue,
+//     'x-one': 123,
+//   };
+//   expect(Example.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import fs from 'fs';
+// import path from 'path';
+
+// import { detailedDiff } from 'deep-object-diff';
+// import yaml from 'js-yaml';
+
+// import { JSONObject } from './jsonUtils';
+// import OpenAPI from './OpenAPI';
+
+// type DetailedDiff = {
+//   added: Record<string, JSONObject>;
+//   deleted: Record<string, JSONObject>;
+//   updated: Record<string, JSONObject>;
+// };
+
+// it.each([['simple'], ['petstore'], ['uspto'], ['callback'], ['api'], ['link']])(
+//   '%s',
+//   (example: string) => {
+//     const inputData = yaml.load(
+//       fs.readFileSync(path.join(__dirname, '..', 'examples', `${example}.yaml`), 'utf-8'),
+//     ) as JSONObject;
+
+//     const openapi = OpenAPI.fromJSON(inputData);
+//     const outputData = openapi.toJSON() as JSONObject;
+//     const dataDiff = detailedDiff(inputData, outputData) as DetailedDiff;
+
+//     const diffCount = Object.entries(dataDiff).reduce((accum, [, diffs]) => {
+//       return accum + Object.keys(diffs).length;
+//     }, 0);
+
+//     if (diffCount > 0) {
+//       fs.writeFileSync(
+//         path.join(__dirname, '..', 'examples', `${example}-out.yaml`),
+//         yaml.dump(outputData),
+//         'utf-8',
+//       );
+
+//       fs.writeFileSync(
+//         path.join(__dirname, '..', 'examples', `${example}-diff.yaml`),
+//         yaml.dump(detailedDiff(inputData, outputData)),
+//         'utf-8',
+//       );
+//     }
+
+//     expect(dataDiff).toEqual({
+//       added: {},
+//       deleted: {},
+//       updated: {},
+//     });
+//   },
+// );
+
+// import { JSONObject } from './jsonUtils';
+// import OpenAPI from './OpenAPI';
+// import ExternalDocumentation from './ExternalDocumentation';
+
+// let parent: OpenAPI;
+
+// beforeEach(() => {
+//   parent = new OpenAPI('Tag.test', '0.0.1');
+// });
+
+// it('fromJSON without required data should throw', () => {
+//   expect(() => ExternalDocumentation.fromJSON(null as unknown as JSONObject, parent)).toThrow();
+//   expect(() => ExternalDocumentation.fromJSON({ description: 'docs' }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON with all the data', () => {
+//   const json = {
+//     url: 'http://www.example.com/docs',
+//     description: 'new docs',
+//     'x-field': { a: 12 },
+//   };
+//   expect(ExternalDocumentation.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import Header from './Header';
+// import Components from './Components';
+// import OpenAPI from './OpenAPI';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Header.test', '0.0.1');
+//   parent = openapi.components;
+// });
+
+// it('fromJSON throws if both the content and schema are given at the same time', () => {
+//   expect(() => Header.fromJSON({ content: {}, schema: { type: 'string' } }, parent)).toThrow();
+// });
+
+// it('fromJSON throws if both example and examples are given at the same time', () => {
+//   expect(() => Header.fromJSON({ example: null, examples: {} }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON are reversible', () => {
+//   const json = {
+//     description: 'desc',
+//     required: true,
+//     deprecated: true,
+//     explode: true,
+//     schema: {
+//       type: 'object',
+//       properties: {
+//         a: {
+//           type: 'string',
+//           nullable: true,
+//         },
+//       },
+//       additionalProperties: false,
+//     },
+//     example: {
+//       a: '1234',
+//     },
+//     'x-ext': 123,
+//   };
+//   expect(Header.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from './OpenAPI';
+// import Info from './Info';
+// import { JSONObject } from './jsonUtils';
+
+// let openapi: OpenAPI;
+
+// beforeEach(() => {
+//   openapi = new OpenAPI('Info.test', '0.0.1');
+// });
+
+// it('fromJSON returns null for nullish input', () => {
+//   expect(Info.fromJSON(null as unknown as JSONObject, openapi)).toBeNull();
+// });
+
+// it('fromJSON throws if input missing required data', () => {
+//   expect(() => Info.fromJSON({}, openapi)).toThrow();
+//   expect(() => Info.fromJSON({ title: 'X' }, openapi)).toThrow();
+//   expect(() => Info.fromJSON({ version: '0.0.1' }, openapi)).toThrow();
+// });
+
+// it('fromJSON + toJSON, only required data', () => {
+//   const json = {
+//     title: 'only required',
+//     version: '2.1.3',
+//   };
+//   expect(Info.fromJSON(json, openapi)?.toJSON()).toEqual(json);
+// });
+
+// it('fromJSON + toJSON, missing contact and license info', () => {
+//   const json = {
+//     title: 'test1',
+//     description: 'test1 - description',
+//     termsOfService: 'http://www.example.com/terms',
+//     version: '0.0.1',
+//   };
+//   expect(Info.fromJSON(json, openapi)?.toJSON()).toEqual(json);
+// });
+
+// it('fromJSON + toJSON, all data present', () => {
+//   const json = {
+//     title: 'test all',
+//     description: 'description',
+//     termsOfService: 'http://www.example.com/terms',
+//     version: '1.0.1',
+//     'x-one': true,
+//     contact: {
+//       name: 'Some developer',
+//       url: 'http://www.example.com/developer',
+//       email: 'someone@example.com',
+//       'x-two': false,
+//     },
+//     license: {
+//       name: 'MIT',
+//       url: 'https://opensource.org/licenses/MIT',
+//       'x-three': 123,
+//     },
+//   };
+//   expect(Info.fromJSON(json, openapi)?.toJSON()).toEqual(json);
+// });
+
+// import Info from './Info';
+// import { JSONObject } from './jsonUtils';
+// import License from './License';
+// import OpenAPI from './OpenAPI';
+
+// let info: Info;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Link.test', '0.0.1');
+//   info = openapi.info;
+// });
+
+// it('fromJSON missing or invalid name', () => {
+//   expect(License.fromJSON(null as unknown as JSONObject, info)).toBeNull();
+//   expect(() => License.fromJSON({}, info)).toThrow();
+//   expect(() => License.fromJSON({ name: null }, info)).toThrow();
+// });
+
+// it('fromJSON + toJSON partial', () => {
+//   const license = License.fromJSON({ name: 'MIT' }, info);
+//   expect(license?.name).toBe('MIT');
+//   expect(license?.url).toBe(null);
+//   expect(license?.toJSON()).toEqual({ name: 'MIT' });
+// });
+
+// it('fromJSON + toJSON', () => {
+//   const json = { name: 'MIT', url: 'https://opensource.org/licenses/MIT' };
+//   expect(License.fromJSON(json, info)?.toJSON()).toEqual(json);
+// });
+
+// import MediaType from './MediaType';
+// import OpenAPI from './OpenAPI';
+// import RequestBody from './RequestBody';
+
+// let parent: RequestBody;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('MediaType.test', '0.0.1');
+//   parent = new RequestBody(openapi.components);
+// });
+
+// it('fromJSON throws if both example and examples are given', () => {
+//   expect(() => MediaType.fromJSON({ example: '123', examples: {} }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON are reversible', () => {
+//   const json = {
+//     schema: {
+//       type: 'object',
+//       properties: {
+//         attr: { type: 'string', nullable: true },
+//       },
+//     },
+//     example: 'abcd',
+//     encoding: {
+//       attr: {
+//         contentType: 'application/string',
+//         style: 'deepObject',
+//       },
+//     },
+//   };
+//   expect(MediaType.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from './OpenAPI';
+
+// const SIMPLE = {
+//   openapi: '3.0.3',
+//   info: {
+//     version: '1.0.0-rc2',
+//     title: 'Sample API',
+//     description: 'A sample API to illustrate OpenAPI concepts',
+//     contact: {
+//       name: 'Author',
+//       email: 'dev@example.com',
+//     },
+//   },
+//   paths: {
+//     '/list': {
+//       get: {
+//         description: 'Returns a list of stuff',
+//         responses: {
+//           '200': {
+//             description: 'Successful response',
+//           },
+//         },
+//       },
+//     },
+//   },
+// };
+
+// describe('OpenAPINode', () => {
+//   it('creates an empty object by default', () => {
+//     const openapi = new OpenAPI('sample', '1.0.0');
+//     expect(openapi.openapi).toBe('3.0.3');
+//     expect(openapi.info.title).toBe('sample');
+//     expect(openapi.info.version).toBe('1.0.0');
+//     expect(openapi.servers).toStrictEqual([]);
+//   });
+
+//   it('should be able to parse a simple schema', () => {
+//     const openapi = OpenAPI.fromJSON(SIMPLE);
+
+//     expect(openapi.info.title).toBe('Sample API');
+//     expect(openapi.info.version).toBe('1.0.0-rc2');
+//     expect(openapi.info.parent).toBe(openapi);
+
+//     expect(openapi.info.contact?.name).toBe('Author');
+//     expect(openapi.info.contact?.parent).toBe(openapi.info);
+//     expect(openapi.info.contact?.root).toBe(openapi);
+
+//     // const pathItems = openapi.paths;
+//     // expect(pathItems.size).toBe(1);
+//   });
+// });
+
+// import OpenAPI from './OpenAPI';
+// import Operation from './Operation';
+// import PathItem from './PathItem';
+
+// let parent: PathItem;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Operation.test', '0.0.1');
+//   parent = new PathItem(openapi.paths);
+// });
+
+// it('fromJSON throws if the responses field is missing or is empty', () => {
+//   expect(() => Operation.fromJSON({ summary: 'op1' }, parent)).toThrow();
+//   expect(() => Operation.fromJSON({ summary: 'op2', responses: {} }, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON are reversible', () => {
+//   const json = {
+//     tags: ['list', 'basic'],
+//     summary: 'list uses',
+//     description: 'Lists available *shops*',
+//     operationId: 'readUserList',
+//     parameters: [
+//       { name: 'query', in: 'query' },
+//       { name: 'offset', in: 'query' },
+//       { name: 'count', in: 'query' },
+//     ],
+//     responses: {
+//       200: {
+//         description: 'Success',
+//         content: {
+//           'application/json': {
+//             schema: {
+//               type: 'array',
+//               items: {
+//                 type: 'string',
+//               },
+//             },
+//           },
+//         },
+//       },
+//       401: {
+//         description: 'Unauthorizes user',
+//       },
+//     },
+//   };
+//   expect(Operation.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from './OpenAPI';
+// import PathItem from './PathItem';
+
+// let parent: OpenAPI;
+
+// beforeEach(() => {
+//   parent = new OpenAPI('PathItem.test', '0.0.1');
+// });
+
+// it('fromJSON should throw if it encountes unknown method', () => {
+//   expect(() =>
+//     PathItem.fromJSON({ teapot: { responses: { 'application/json': {} } } }, parent.paths),
+//   ).toThrow();
+// });
+
+// it('fromJSON + toJSON are reversible', () => {
+//   const json = {
+//     summary: 'summary',
+//     description: 'description',
+//     servers: [{ url: 'http://api.example.com' }],
+//     parameters: [
+//       { name: 'search', in: 'query' },
+//       { name: 'offset', in: 'query' },
+//       { name: 'count', in: 'query' },
+//     ],
+//     get: {
+//       responses: {
+//         200: {
+//           description: 'success',
+//           content: {
+//             'application/json': {
+//               schema: {
+//                 type: 'string',
+//               },
+//             },
+//           },
+//         },
+//       },
+//     },
+//     'x-ext': 123,
+//   };
+//   expect(PathItem.fromJSON(json, parent.paths).toJSON()).toEqual(json);
+// });
+
+// import Components from './Components';
+// import OpenAPI from './OpenAPI';
+// import RequestBody from './RequestBody';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('RequestBody.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON + toJSON should be revesible', () => {
+//   const json = {
+//     description: 'request body',
+//     content: {
+//       'application/json': {
+//         schema: {
+//           type: 'string',
+//         },
+//       },
+//       'application/text': {
+//         example: 'textual request body',
+//       },
+//     },
+//     required: true,
+//   };
+//   expect(RequestBody.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import Components from './Components';
+// import OpenAPI from './OpenAPI';
+// import Response from './Response';
+
+// let parent: Components;
+
+// beforeEach(() => {
+//   const openapi = new OpenAPI('Response.test', '0.0.1');
+//   parent = new Components(openapi);
+// });
+
+// it('fromJSON should throw if not description has been given', () => {
+//   expect(() => Response.fromJSON({ headers: {}, content: {}, links: {} }, parent)).toThrow();
+// });
+
+// it('fromJSON throws on duplicate headers', () => {
+//   expect(() =>
+//     Response.fromJSON(
+//       {
+//         description: 'complete response',
+//         headers: {
+//           'accept-language': {},
+//           'Accept-Language': {},
+//         },
+//       },
+//       parent,
+//     ),
+//   ).toThrow();
+// });
+
+// it('fromJSON ignores content-type header', () => {
+//   expect(
+//     Response.fromJSON(
+//       {
+//         description: 'complete response',
+//         headers: {
+//           'content-type': {},
+//           'x-schema': {},
+//         },
+//       },
+//       parent,
+//     ).toJSON(),
+//   ).toEqual({
+//     description: 'complete response',
+//     headers: {
+//       'x-schema': {},
+//     },
+//   });
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     description: 'complete response',
+//     headers: {
+//       'x-language': {},
+//       'x-schema': {},
+//     },
+//     content: {
+//       'application/json': {
+//         schema: {
+//           type: 'string',
+//         },
+//       },
+//       'application/text': {
+//         example: 'string example',
+//       },
+//     },
+//     links: {
+//       link1: { operationId: 'op1' },
+//       link2: { operationId: 'op2' },
+//     },
+//   };
+//   expect(Response.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import OpenAPI from './OpenAPI';
+// import SecurityRequirement from './SecurityRequirement';
+
+// let parent: OpenAPI;
+
+// beforeEach(() => {
+//   parent = new OpenAPI('Tag.test', '0.0.1');
+// });
+
+// it('does not support extensions, treating them as scheme names', () => {
+//   expect(
+//     SecurityRequirement.fromJSON(
+//       {
+//         api: [],
+//         'x-ext': [],
+//       },
+//       parent,
+//     ).toJSON(),
+//   ).toEqual({ api: [], 'x-ext': [] });
+// });
+
+// it('fromJSON + toJSON should be reversible', () => {
+//   const json = {
+//     api1: ['user:read', 'user:write'],
+//     http2: [],
+//     cookie3: [],
+//   };
+//   expect(SecurityRequirement.fromJSON(json, parent).toJSON()).toEqual(json);
+// });
+
+// import { JSONObject } from './jsonUtils';
+// import OpenAPI from './OpenAPI';
+// import Server from './Server';
+
+// let parent: OpenAPI;
+
+// beforeEach(() => {
+//   parent = new OpenAPI('Server.test', '0.0.1');
+// });
+
+// it('fromJSON throws when missing required data', () => {
+//   expect(() => Server.fromJSON(null as unknown as JSONObject, parent)).toThrow();
+//   expect(() => Server.fromJSON({}, parent)).toThrow();
+// });
+
+// it('fromJSON throws when variable data is missing', () => {
+//   const json = {
+//     url: 'http://{version}.example.com/{rootPath}',
+//     description: 'API server',
+//     variables: {
+//       version: {
+//         default: 'v2',
+//         description: 'latest',
+//         enum: ['v1', 'v2'],
+//       },
+//     },
+//     'x-one': 1,
+//   };
+//   expect(() => Server.fromJSON(json, parent)).toThrow();
+// });
+
+// it('fromJSON + toJSON, all data', () => {
+//   const json = {
+//     url: 'http://{version}.example.com',
+//     description: 'API server',
+//     variables: {
+//       version: {
+//         default: 'v2',
+//         description: 'latest',
+//         enum: ['v1', 'v2'],
+//       },
+//     },
+//     'x-one': 1,
+//   };
+//   expect(Server.fromJSON(json, parent).toJSON()).toEqual(json);
+// });

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
@@ -1,0 +1,1081 @@
+import assert from 'assert';
+import fs from 'fs';
+
+import yaml from 'yaml';
+
+import { Callback, CallbackParent } from './Callback';
+import { Components } from './Components';
+import { Contact, ContactParent } from './Contact';
+import { Discriminator, DiscriminatorParent } from './Discriminator';
+import {
+  Encoding,
+  EncodingParent,
+  SerializationStyle as EncodingSerializationStyle,
+} from './Encoding';
+import { Example, ExampleParent } from './Example';
+import { ExternalDocumentation, ExternalDocumentationParent } from './ExternalDocumentation';
+import { Header, HeaderParent, SerializationStyle as HeaderSerializationStyle } from './Header';
+import { Info, InfoParent } from './Info';
+import { License, LicenseParent } from './License';
+import { Link, LinkParent } from './Link';
+import { MediaType, MediaTypeParent } from './MediaType';
+import { OAuthFlow, OAuthFlowParent } from './OAuthFlow';
+import { OAuthAuthorisationCodeFlow } from './OAuthFlow/OAuthAuthorisationCodeFlow';
+import { OAuthClientCredentialsFlow } from './OAuthFlow/OAuthClientCredentialsFlow';
+import { OAuthImplicitFlow } from './OAuthFlow/OAuthImplicitFlow';
+import { OAuthPasswordFlow } from './OAuthFlow/OAuthPasswordFlow';
+import { OpenAPI } from './OpenAPI';
+import { Operation, OperationParent } from './Operation';
+import { QueryParameter, Parameter, ParameterParent, PathParameter } from './Parameter';
+import {
+  CookieParameter,
+  SerializationStyle as CookieParameterSerializationStyle,
+} from './Parameter/CookieParameter';
+import {
+  HeaderParameter,
+  SerializationStyle as HeaderParameterSerializationStyle,
+} from './Parameter/HeaderParameter';
+import { defaultExplode } from './Parameter/utils';
+import { PathItem, httpMethods, PathItemParent, whitelistedProperties } from './PathItem';
+import { RequestBody, RequestBodyParent } from './RequestBody';
+import { Response, ResponseParent } from './Response';
+import { Schema, SchemaParent } from './Schema';
+import { SecurityRequirement, SecurityRequirementParent } from './SecurityRequirement';
+import { SecurityScheme, SecuritySchemeParent } from './SecurityScheme';
+import { ApiKeyScheme } from './SecurityScheme/ApiKeyScheme';
+import { HttpScheme } from './SecurityScheme/HttpScheme';
+import { OAuth2Scheme } from './SecurityScheme/OAuth2Scheme';
+import { OpenIdConnectScheme } from './SecurityScheme/OpenIdConnectScheme';
+import { Server, ServerParent } from './Server';
+import { Tag, TagParent } from './Tag';
+import { XML, XMLParent } from './XML';
+
+import type {
+  ComponentsObject,
+  ContactObject,
+  DiscriminatorObject,
+  EncodingObject,
+  ExampleObject,
+  InfoObject,
+  LicenseObject,
+  LinkObject,
+  ObjectOrRef,
+  OpenAPIObject,
+  Ref,
+  SchemaFormat,
+  SchemaObject,
+  SchemaType,
+  SecurityRequirementObject,
+  ServerObject,
+  ServerVariableObject,
+  XMLObject,
+} from '../types';
+import type { ExtensionFields } from './BasicNode';
+import type { ServerVariable } from './ServerVariable';
+import type {
+  HTTPMethod,
+  QueryParameterSerializationStyle,
+  PathParameterSerializationStyle,
+} from './types';
+import type { Nullable, JSONObject, JSONArray } from '@fresha/api-tools-core';
+
+const isRef = (arg: unknown): arg is Ref => {
+  return arg != null && '$ref' in arg;
+};
+
+const isEmpty = (obj?: JSONObject): boolean => {
+  return !obj || !Object.keys(obj).length;
+};
+
+const getStringAttribute = (
+  json: JSONObject | undefined,
+  name: string,
+  required = true,
+): Nullable<string> => {
+  if (json == null) {
+    return null;
+  }
+  const result = json[name];
+  if (typeof result === 'string') {
+    return result;
+  }
+  if (!required && result == null) {
+    return null;
+  }
+  throw new Error(
+    `Property ${name} is expected to be a string, but it is ${typeof result} instead`,
+  );
+};
+
+const getNumericAttribute = (
+  json: JSONObject | undefined,
+  name: string,
+  required = true,
+): Nullable<number> => {
+  if (json == null) {
+    return null;
+  }
+  const result = json[name];
+  if (typeof result === 'number') {
+    return result;
+  }
+  if (!required && result == null) {
+    return null;
+  }
+  throw new Error(
+    `Property ${name} is expected to be a number, but it is ${typeof result} instead`,
+  );
+};
+
+export class OpenAPIReader {
+  private readonly schemaPointers: Map<string, unknown>;
+
+  private components?: Components;
+  private componentsSchemas?: Record<string, ObjectOrRef<SchemaObject>>;
+  private componentsLinks?: Record<string, ObjectOrRef<LinkObject>>;
+
+  constructor() {
+    this.schemaPointers = new Map<string, unknown>();
+  }
+
+  parseFromFile(fileName: string): OpenAPI {
+    const text = fs.readFileSync(fileName, 'utf-8');
+    const data = yaml.parse(text) as OpenAPIObject;
+    return this.parse(data);
+  }
+
+  parse(json: OpenAPIObject): OpenAPI {
+    this.schemaPointers.clear();
+    this.components = undefined;
+    this.componentsSchemas = undefined;
+    this.componentsLinks = undefined;
+
+    const result = new OpenAPI(json.info.title, json.info.version);
+    this.schemaPointers.set('#/', result);
+
+    this.parseExtensionFields(result.extensions, json);
+
+    result.info = this.parseInfo(json.info, result);
+
+    if (json.servers) {
+      result.servers = json.servers.map(item => this.parseServer(item, result));
+    }
+
+    this.parseComponents(result.components, json.components);
+
+    for (const [path, pathItemJson] of Object.entries(json.paths)) {
+      if (!path.startsWith('x-')) {
+        const pathItem = this.parsePathItem(pathItemJson as JSONObject, result.paths);
+        result.paths.set(path, pathItem);
+      }
+    }
+
+    if ('security' in json) {
+      result.security = this.parseSecurityRequirement(result, json.security);
+    }
+
+    if (json.tags?.length) {
+      for (const tagJson of json.tags) {
+        const tag = this.parseTag(tagJson, result);
+        result.tags.push(tag);
+      }
+    }
+
+    if (json.externalDocs) {
+      result.externalDocs = this.parseExternalDocumentation(json.externalDocs, result);
+    }
+
+    return result;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private parseExtensionFields(
+    extensionFields: ExtensionFields,
+    json?: JSONObject,
+    reset = false,
+  ): void {
+    if (reset) {
+      extensionFields.clear();
+    }
+    if (json != null) {
+      for (const [key, value] of Object.entries(json)) {
+        if (key.startsWith('x-')) {
+          extensionFields.set(key.slice(2), value);
+        }
+      }
+    }
+  }
+
+  private parseInfo(json: InfoObject, parent: InfoParent): Info {
+    assert(json != null);
+    assert(typeof json.title === 'string');
+    assert(typeof json.version === 'string');
+    const result = new Info(parent, json.title, json.version);
+    this.schemaPointers.set('#/info', result);
+    this.schemaPointers.set('#/info/contact', result.contact);
+    this.schemaPointers.set('#/info/license', result.license);
+    this.parseExtensionFields(result.extensions, json);
+    result.description = getStringAttribute(json, 'description', false);
+    result.termsOfService = getStringAttribute(json, 'termsOfService', false);
+    this.parseContact(result, json.contact);
+    this.parseLicense(result, json.license);
+    return result;
+  }
+
+  private parseContact(parent: ContactParent, json?: ContactObject): Nullable<Contact> {
+    if (isEmpty(json)) {
+      return null;
+    }
+    const result = parent.contact;
+    this.parseExtensionFields(result.extensions, json);
+    result.name = getStringAttribute(json, 'name', false);
+    result.url = getStringAttribute(json, 'url', false);
+    result.email = getStringAttribute(json, 'email', false);
+    return result;
+  }
+
+  private parseLicense(parent: LicenseParent, json?: LicenseObject): Nullable<License> {
+    if (json == null) {
+      return null;
+    }
+
+    const result = parent.license;
+    this.parseExtensionFields(result.extensions, json);
+    result.name = getStringAttribute(json, 'name') as string;
+    result.url = getStringAttribute(json, 'url', false);
+    return result;
+  }
+
+  private parseServer(json: ServerObject, parent: ServerParent): Server {
+    assert(typeof json.url === 'string');
+    const result = new Server(parent, json.url);
+    this.parseExtensionFields(result.extensions, json);
+    result.description = getStringAttribute(json, 'description', false);
+    if (json.variables) {
+      for (const [key, value] of Object.entries(json.variables)) {
+        const variable = result.variables.get(key);
+        assert(variable, `Missing server variable named ${key}`);
+        this.parseServerVariable(value, variable);
+      }
+    }
+    return result;
+  }
+
+  private parseServerVariable(json: ServerVariableObject, variable: ServerVariable): void {
+    this.parseExtensionFields(variable.extensions, json);
+    variable.default = getStringAttribute(json, 'default') as string;
+    if (Array.isArray(json.enum) && json.enum.length) {
+      variable.enum = json.enum.slice();
+    }
+    variable.description = getStringAttribute(json, 'description', false);
+  }
+
+  private parseComponents(result: Components, json?: ComponentsObject): Components {
+    this.schemaPointers.set('#/components', result);
+    this.components = result;
+
+    if (!json) {
+      return result;
+    }
+
+    this.parseExtensionFields(result.extensions, json);
+
+    if (json.schemas) {
+      this.componentsSchemas = json.schemas;
+
+      for (const [key, value] of Object.entries(json.schemas)) {
+        if (!result.schemas.has(key)) {
+          const schema = this.parseSchema(value, result);
+          result.schemas.set(key, schema);
+          this.schemaPointers.set(`#/components/schemas/${key}`, schema);
+        }
+      }
+    }
+    if (json.responses) {
+      for (const [key, responseJson] of Object.entries(json.responses)) {
+        const response = this.parseResponse(responseJson, result);
+        result.responses.set(key, response);
+        this.schemaPointers.set(`#/components/responses/${key}`, response);
+      }
+    }
+    if (json.parameters) {
+      for (const [key, parameterJson] of Object.entries(json.parameters)) {
+        const parameter = this.parseParameter(parameterJson as JSONObject, result);
+        result.parameters.set(key, parameter as PathParameter);
+        this.schemaPointers.set(`#/components/parameters/${key}`, parameter);
+      }
+    }
+    if (json.examples) {
+      for (const [key, exampleJson] of Object.entries(json.examples)) {
+        const example = this.parseExample(exampleJson as JSONObject, result);
+        result.examples.set(key, example);
+        this.schemaPointers.set(`#/components/examples/${key}`, example);
+      }
+    }
+    if (json.requestBodies) {
+      for (const [key, requestBodyJson] of Object.entries(json.requestBodies)) {
+        const requestBody = this.parseRequestBody(requestBodyJson as JSONObject, result);
+        result.requestBodies.set(key, requestBody);
+        this.schemaPointers.set(`#/components/requestBodies/${key}`, requestBody);
+      }
+    }
+    if (json.headers) {
+      for (const [key, headerJson] of Object.entries(json.headers)) {
+        const header = this.parseHeader(headerJson as JSONObject, result);
+        result.headers.set(key, header);
+        this.schemaPointers.set(`#/components/headers/${key}`, header);
+      }
+    }
+    if (json.securitySchemas) {
+      for (const [key, securitySchemeJson] of Object.entries(json.securitySchemas)) {
+        const securityScheme = this.parseSecurityScheme(securitySchemeJson as JSONObject, result);
+        result.securitySchemas.set(key, securityScheme);
+        this.schemaPointers.set(`#/components/securitySchemas/${key}`, securityScheme);
+      }
+    }
+    if (json.links) {
+      this.componentsLinks = json.links;
+
+      for (const [key, linkJson] of Object.entries(json.links)) {
+        if (!this.components.links.has(key)) {
+          const link = this.parseLink(linkJson as JSONObject, result);
+          result.links.set(key, link);
+          this.schemaPointers.set(`#/components/links/${key}`, link);
+        }
+      }
+    }
+    if (json.callbacks) {
+      for (const [key, callbackJson] of Object.entries(json.callbacks)) {
+        const callback = this.parseCallback(callbackJson as JSONObject, result);
+        result.callbacks.set(key, callback);
+        this.schemaPointers.set(`#/components/callbacks/${key}`, callback);
+      }
+    }
+
+    return result;
+  }
+
+  private resolveSchemaFromRef(ref: string): Schema {
+    let result = this.schemaPointers.get(ref);
+    if (result) {
+      assert(result instanceof Schema, `Resolved reference ${ref} is not a Schema instance`);
+      return result;
+    }
+
+    const key = ref.split('/').at(-1);
+    assert(typeof key === 'string');
+
+    assert(this.components);
+    assert(this.componentsSchemas);
+    const json = this.componentsSchemas[key];
+
+    result = this.parseSchema(json, this.components);
+    this.components.schemas.set(key, result as Schema);
+    this.schemaPointers.set(`#/components/schemas/${key}`, result);
+
+    return result as Schema;
+  }
+
+  private parseSchema(json: ObjectOrRef<SchemaObject>, parent: SchemaParent): Schema {
+    if (isRef(json)) {
+      return this.resolveSchemaFromRef(json.$ref);
+    }
+
+    const schema = new Schema(parent);
+    this.parseExtensionFields(schema.extensions, json);
+    schema.title = getStringAttribute(json, 'title', false);
+    schema.multipleOf = getNumericAttribute(json, 'multipleOf', false);
+    schema.maximum = getNumericAttribute(json, 'maximum', false);
+    schema.exclusiveMaximum = !!json.exclusiveMaximum;
+    schema.minimum = getNumericAttribute(json, 'minimum', false);
+    schema.exclusiveMinimum = !!json.exclusiveMinimum;
+    schema.minLength = getNumericAttribute(json, 'minLength', false);
+    schema.maxLength = getNumericAttribute(json, 'maxLength', false);
+    schema.pattern = getStringAttribute(json, 'pattern', false);
+    schema.minItems = getNumericAttribute(json, 'minItems', false);
+    schema.maxItems = getNumericAttribute(json, 'maxItems', false);
+    schema.uniqueItems = !!json.uniqueItems;
+    schema.minProperties = getNumericAttribute(json, 'minProperties', false);
+    schema.maxProperties = getNumericAttribute(json, 'maxProperties', false);
+    for (const elem of json.required ?? []) {
+      schema.required.add(elem);
+    }
+    schema.enum = json.enum ?? null;
+    schema.type = getStringAttribute(json, 'type', false) as SchemaType;
+    if (json.allOf) {
+      schema.allOf = json.allOf.map(subSchemaJson => this.parseSchema(subSchemaJson, schema));
+    }
+    if (json.oneOf) {
+      schema.oneOf = json.oneOf.map(subSchemaJson => this.parseSchema(subSchemaJson, schema));
+    }
+    if (json.anyOf) {
+      schema.anyOf = json.anyOf.map(subSchemaJson => this.parseSchema(subSchemaJson, schema));
+    }
+    if (json.not) {
+      schema.not = this.parseSchema(json.not, schema);
+    }
+    if (json.items) {
+      schema.items = this.parseSchema(json.items, schema);
+    }
+    if (json.properties) {
+      for (const [key, value] of Object.entries(json.properties)) {
+        schema.properties.set(key, this.parseSchema(value, schema));
+      }
+    }
+    if ('additionalProperties' in json) {
+      if (typeof json.additionalProperties === 'boolean') {
+        schema.additionalProperties = json.additionalProperties;
+      } else if (json.additionalProperties) {
+        schema.additionalProperties = this.parseSchema(json.additionalProperties, schema);
+      }
+    }
+    schema.description = getStringAttribute(json, 'description', false);
+    schema.format = getStringAttribute(json, 'format', false) as SchemaFormat;
+    if ('default' in json) {
+      schema.default = json.default ?? null;
+    }
+    schema.nullable = !!json.nullable;
+    if (json.discriminator) {
+      schema.discriminator = this.parseDiscriminator(json.discriminator, schema);
+    }
+    schema.readOnly = !!json.readOnly;
+    schema.writeOnly = !!json.writeOnly;
+    if (json.xml) {
+      schema.xml = this.parseXML(json.xml, schema);
+    }
+    if (json.externalDocs) {
+      schema.externalDocs = this.parseExternalDocumentation(json.externalDocs, schema);
+    }
+    if ('example' in json) {
+      schema.example = json.example ?? null;
+    }
+    schema.deprecated = !!json.deprecated;
+
+    return schema;
+  }
+
+  private parseResponse(json: JSONObject, parent: ResponseParent): Response {
+    const result = new Response(
+      parent,
+      (getStringAttribute(json, 'description', false) as string) ?? 'x',
+    );
+    if (json.headers) {
+      for (const [key, headerJson] of Object.entries(json.headers as JSONObject)) {
+        const headerName = key.toLowerCase();
+        if (result.headers.has(headerName)) {
+          throw new Error(`Duplicate response header ${key}`);
+        }
+        if (headerName !== 'content-type') {
+          const header = this.parseHeader(headerJson as JSONObject, result);
+          result.headers.set(key.toLowerCase(), header);
+        }
+      }
+    }
+    if (json.content) {
+      for (const [key, contentJson] of Object.entries(json.content as JSONObject)) {
+        const content = this.parseMediaType(contentJson as JSONObject, result);
+        result.content.set(key, content);
+      }
+    }
+    if (json.links) {
+      for (const [linkId, linkJson] of Object.entries(json.links as JSONObject)) {
+        const link = this.parseLink(linkJson as JSONObject, result);
+        result.links.set(linkId, link);
+      }
+    }
+    return result;
+  }
+
+  private parseHeader(json: JSONObject, parent: HeaderParent): Header {
+    if ('schema' in json && 'content' in json) {
+      throw new Error(`Either schema or content should be present, but not both`);
+    }
+    if ('example' in json && 'examples' in json) {
+      throw new Error(`Either example or examples should be present, but not both`);
+    }
+
+    const result = new Header(parent);
+    this.parseExtensionFields(result.extensions, json);
+    if (json.description) {
+      result.description = json.description as string;
+    }
+    if (json.required) {
+      result.required = json.required as boolean;
+    }
+    if (json.deprecated) {
+      result.deprecated = json.deprecated as boolean;
+    }
+    if (json.style) {
+      result.style = getStringAttribute(json, 'style', false) as HeaderSerializationStyle;
+    }
+    if (json.explode) {
+      result.explode = json.explode as boolean;
+    }
+    if (json.schema) {
+      result.schema = this.parseSchema(json.schema as SchemaObject, result);
+    }
+    if (json.example) {
+      result.example = json.example;
+    }
+    if (json.examples) {
+      for (const [key, value] of Object.entries(json.examples as JSONObject)) {
+        const example = this.parseExample(value as JSONObject, result);
+        result.examples.set(key, example);
+      }
+    }
+    return result;
+  }
+
+  private parseExample(json: ExampleObject, parent: ExampleParent): Example {
+    const result = new Example(parent);
+    this.parseExtensionFields(result.extensions, json);
+    result.summary = getStringAttribute(json, 'summary', false);
+    result.description = getStringAttribute(json, 'description', false);
+    result.value = json.value ?? null;
+    const externalValue = getStringAttribute(json, 'externalValue', false);
+    if (result.value != null && externalValue != null) {
+      throw new Error(`Either Example.value or Example.externalValue can be supplied at a time`);
+    }
+    result.externalValue = externalValue;
+    return result;
+  }
+
+  private parseMediaType(json: JSONObject, parent: MediaTypeParent): MediaType {
+    if (json.example && json.examples) {
+      throw new Error(`Either example or examples should be set, but not both`);
+    }
+    const result = new MediaType(parent);
+    if (json.schema) {
+      result.schema = this.parseSchema(json.schema as SchemaObject, result);
+    }
+    if (json.example) {
+      result.example = json.example;
+    }
+    if (json.examples) {
+      for (const [key, exampleJson] of Object.entries(json.examples as JSONObject)) {
+        const example = this.parseExample(exampleJson as JSONObject, result);
+        result.examples.set(key, example);
+      }
+    }
+    if (json.encoding) {
+      for (const [mimeType, encodingJson] of Object.entries(json.encoding as JSONObject)) {
+        const encoding = this.parseEncoding(encodingJson as JSONObject, result);
+        result.encoding.set(mimeType, encoding);
+      }
+    }
+    return result;
+  }
+
+  private parseEncoding(json: EncodingObject, parent: EncodingParent): Encoding {
+    const result = new Encoding(
+      parent,
+      getStringAttribute(json as JSONObject, 'contentType') as string,
+    );
+    if (json.headers) {
+      for (const [key, headerJson] of Object.entries(json.headers as JSONObject)) {
+        const headerName = key.toLowerCase();
+        const header = this.parseHeader(headerJson as JSONObject, result);
+        result.headers.set(headerName, header);
+      }
+    }
+    if (json.style) {
+      result.style = getStringAttribute(
+        json as JSONObject,
+        'style',
+        false,
+      ) as EncodingSerializationStyle;
+    }
+    if (json.explode) {
+      result.explode = json.explode as boolean;
+    }
+    if (json.allowReserved) {
+      result.allowReserved = json.allowReserved as boolean;
+    }
+    return result;
+  }
+
+  private resolveLinkFromRef(ref: string): Link {
+    let result = this.schemaPointers.get(ref);
+    if (result) {
+      assert(result instanceof Link, `Resolved reference ${ref} is not a Link instance`);
+      return result;
+    }
+
+    const key = ref.split('/').at(-1);
+    assert(typeof key === 'string');
+
+    assert(this.components);
+    assert(this.componentsLinks);
+    const json = this.componentsLinks[key];
+
+    result = this.parseLink(json, this.components);
+    this.components.links.set(key, result as Link);
+    this.schemaPointers.set(`#/components/links/${key}`, result);
+
+    return result as Link;
+  }
+
+  private parseLink(json: ObjectOrRef<LinkObject>, parent: LinkParent): Link {
+    if (isRef(json)) {
+      return this.resolveLinkFromRef(json.$ref);
+    }
+
+    const result = new Link(parent);
+    this.parseExtensionFields(result.extensions, json);
+    if ('operationId' in json) {
+      result.operationId = json.operationId as string;
+    }
+    if (!isEmpty(json.parameters as JSONObject)) {
+      for (const [paramName, paramValue] of Object.entries(json.parameters as JSONObject)) {
+        result.parameters.set(paramName, paramValue);
+      }
+    }
+    return result;
+  }
+
+  private parseParameter(json: JSONObject, parent: ParameterParent): Parameter {
+    switch (json.in) {
+      case 'path':
+        return this.parsePathParameter(json, parent);
+      case 'query':
+        return this.parseQueryParameter(json, parent);
+      case 'cookie':
+        return this.parseCookieParameter(json, parent);
+      case 'header':
+        return this.parseHeaderParameter(json, parent);
+      default:
+        throw new Error(`Unsupported parameter type ${String(json.in)}`);
+    }
+  }
+
+  private parseParameterCommon(json: JSONObject, parameter: Parameter): void {
+    this.parseExtensionFields(parameter.extensions, json);
+    parameter.description = getStringAttribute(json, 'description', false);
+    if (json.deprecated) {
+      parameter.deprecated = json.deprecated as boolean;
+    }
+    if ('schema' in json && 'content' in json) {
+      throw new Error(`Either schema or content should be present, but not both`);
+    }
+    if ('schema' in json) {
+      parameter.schema = this.parseSchema(json.schema as SchemaObject, parameter);
+    }
+    if ('content' in json) {
+      for (const [mimeType, mediaTypeJson] of Object.entries(json.content as JSONObject)) {
+        const mediaType = this.parseMediaType(mediaTypeJson as JSONObject, parameter);
+        parameter.content.set(mimeType, mediaType);
+      }
+    }
+    if ('example' in json && 'examples' in json) {
+      throw new Error(`Either example or examples should be present, but not both`);
+    }
+    if (json.example) {
+      parameter.example = json.example;
+    }
+    if (json.examples) {
+      for (const [key, value] of Object.entries(json.examples as JSONObject)) {
+        const example = this.parseExample(value as JSONObject, parameter);
+        parameter.examples.set(key, example);
+      }
+    }
+  }
+
+  private parsePathParameter(json: JSONObject, parent: ParameterParent): PathParameter {
+    if (json.in !== 'path') {
+      throw new Error(`Wrong in parameter for HeaderParameter ${String(json.in)}`);
+    }
+    const result = new PathParameter(parent, getStringAttribute(json, 'name') as string);
+    this.parseParameterCommon(json, result);
+    if (json.required != null && !json.required) {
+      throw new Error('Path parameters are always required');
+    }
+    if (json.style) {
+      result.style = getStringAttribute(json, 'style', false) as PathParameterSerializationStyle;
+    }
+    result.explode = ('explode' in json ? json.explode : defaultExplode[result.style]) as boolean;
+    return result;
+  }
+
+  private parseQueryParameter(json: JSONObject, parent: ParameterParent): QueryParameter {
+    if (json.in !== 'query') {
+      throw new Error(`Wrong in parameter for HeaderParameter ${String(json.in)}`);
+    }
+    const result = new QueryParameter(parent, getStringAttribute(json, 'name') as string);
+    this.parseParameterCommon(json, result);
+    if (json.required) {
+      result.required = json.required as boolean;
+    }
+    if (json.style) {
+      result.style = getStringAttribute(json, 'style', false) as QueryParameterSerializationStyle;
+    }
+    result.explode = ('explode' in json ? json.explode : defaultExplode[result.style]) as boolean;
+    if (json.allowEmptyValue) {
+      result.allowEmptyValue = json.allowEmptyValue as boolean;
+    }
+    if (json.allowReserved) {
+      result.allowReserved = json.allowReserved as boolean;
+    }
+    return result;
+  }
+
+  private parseHeaderParameter(json: JSONObject, parent: ParameterParent): HeaderParameter {
+    if (json.in !== 'header') {
+      throw new Error(`Wrong in parameter for HeaderParameter ${String(json.in)}`);
+    }
+    const result = new HeaderParameter(parent, getStringAttribute(json, 'name') as string);
+    this.parseParameterCommon(json, result);
+    if (json.required) {
+      result.required = json.required as boolean;
+    }
+    if (json.style) {
+      result.style = getStringAttribute(json, 'style', false) as HeaderParameterSerializationStyle;
+    }
+    result.explode = ('explode' in json ? json.explode : defaultExplode[result.style]) as boolean;
+    return result;
+  }
+
+  private parseCookieParameter(json: JSONObject, parent: ParameterParent): CookieParameter {
+    if (json.in !== 'cookie') {
+      throw new Error(`Wrong in parameter for CookieParameter ${String(json.in)}`);
+    }
+    const result = new CookieParameter(parent, getStringAttribute(json, 'name') as string);
+    this.parseParameterCommon(json, result);
+    if (json.required) {
+      result.required = json.required as boolean;
+    }
+    if (json.style) {
+      result.style = getStringAttribute(json, 'style', false) as CookieParameterSerializationStyle;
+    }
+    result.explode = ('explode' in json ? json.explode : defaultExplode[result.style]) as boolean;
+    return result;
+  }
+
+  private parseRequestBody(json: JSONObject, parent: RequestBodyParent): RequestBody {
+    const result = new RequestBody(parent);
+    result.description = getStringAttribute(json, 'description', false) as string;
+    if (json.content) {
+      for (const [mediaTypeName, mediaTypeData] of Object.entries(json.content)) {
+        result.content.set(mediaTypeName, this.parseMediaType(mediaTypeData as JSONObject, result));
+      }
+    }
+    result.required = json.required as boolean;
+    return result;
+  }
+
+  private parseSecurityScheme(json: JSONObject, parent: SecuritySchemeParent): SecurityScheme {
+    switch (json.type) {
+      case 'apiKey':
+        return this.parseApiKeySecurityScheme(json, parent);
+      case 'http':
+        return this.parseHttpSecurityScheme(json, parent);
+      case 'oauth2':
+        return this.parseOauth2SecurityScheme(json, parent);
+      case 'openIdConnect':
+        return this.parseOpenIdConnectScheme(json, parent);
+      default:
+        throw new Error(`Unsupported security scheme type ${json.type as string}`);
+    }
+  }
+
+  private parseSecuritySchemeCommon(json: JSONObject, securitySchema: SecurityScheme): void {
+    this.parseExtensionFields(securitySchema.extensions, json);
+    securitySchema.description = getStringAttribute(json, 'description', false);
+  }
+
+  private parseApiKeySecurityScheme(json: JSONObject, parent: SecuritySchemeParent): ApiKeyScheme {
+    if (json.type !== 'apiKey') {
+      throw new Error(`Incorrent type value ${String(json.type)}`);
+    }
+    const result = new ApiKeyScheme(
+      parent,
+      getStringAttribute(json, 'name') as string,
+      getStringAttribute(json, 'in') as 'cookie' | 'header' | 'query',
+    );
+    this.parseSecuritySchemeCommon(json, result);
+    return result;
+  }
+
+  private parseHttpSecurityScheme(json: JSONObject, parent: SecuritySchemeParent): HttpScheme {
+    if (json.type !== 'http') {
+      throw new Error(`Incorrent type value ${String(json.type)}`);
+    }
+    const result = new HttpScheme(parent);
+    this.parseSecuritySchemeCommon(json, result);
+    result.scheme = this.parseSchema(json.schema as SchemaObject, result);
+    result.bearerFormat = getStringAttribute(json, 'bearerFormat', false);
+    return result;
+  }
+
+  private parseOauth2SecurityScheme(json: JSONObject, parent: SecuritySchemeParent): OAuth2Scheme {
+    if (json.type !== 'oauth2') {
+      throw new Error(`Incorrent type value ${String(json.type)}`);
+    }
+
+    const result = new OAuth2Scheme(parent);
+    this.parseSecuritySchemeCommon(json, result);
+
+    const { authorizationCode, clientCredentials, implicit, password } = json.flows as JSONObject;
+    if (authorizationCode) {
+      result.flows.authorizationCode = this.parseAuthorisationCodeOAuthFlow(
+        authorizationCode as JSONObject,
+        result.flows,
+      );
+    }
+    if (clientCredentials) {
+      result.flows.clientCredentials = this.parseClientCredentialsOAuthFlow(
+        clientCredentials as JSONObject,
+        result.flows,
+      );
+    }
+    if (implicit) {
+      result.flows.implicit = this.parseImplicitOAuthFlow(implicit as JSONObject, result.flows);
+    }
+    if (password) {
+      result.flows.password = this.parsePasswordOAuthFlow(password as JSONObject, result.flows);
+    }
+
+    return result;
+  }
+
+  private parseOAuthFlowCommon(json: JSONObject, flow: OAuthFlow): void {
+    this.parseExtensionFields(flow.extensions, json);
+    flow.refreshUrl = getStringAttribute(json, 'refreshUrl', false);
+    if (json.scopes) {
+      for (const [key, value] of Object.entries(json.scopes as JSONObject)) {
+        flow.scopes.set(key, value as string);
+      }
+    }
+  }
+
+  private parseAuthorisationCodeOAuthFlow(
+    json: JSONObject,
+    parent: OAuthFlowParent,
+  ): OAuthAuthorisationCodeFlow {
+    const result = new OAuthAuthorisationCodeFlow(
+      parent,
+      getStringAttribute(json, 'authorizationUrl') as string,
+      getStringAttribute(json, 'tokenUrl') as string,
+    );
+    this.parseOAuthFlowCommon(json, result);
+    return result;
+  }
+
+  private parseClientCredentialsOAuthFlow(
+    json: JSONObject,
+    parent: OAuthFlowParent,
+  ): OAuthClientCredentialsFlow {
+    const result = new OAuthClientCredentialsFlow(
+      parent,
+      getStringAttribute(json, 'tokenUrl') as string,
+    );
+    this.parseOAuthFlowCommon(json, result);
+    return result;
+  }
+
+  private parseImplicitOAuthFlow(json: JSONObject, parent: OAuthFlowParent): OAuthImplicitFlow {
+    const result = new OAuthImplicitFlow(
+      parent,
+      getStringAttribute(json, 'authorizationUrl') as string,
+    );
+    this.parseOAuthFlowCommon(json, result);
+    return result;
+  }
+
+  private parsePasswordOAuthFlow(json: JSONObject, parent: OAuthFlowParent): OAuthPasswordFlow {
+    const result = new OAuthPasswordFlow(parent, getStringAttribute(json, 'tokenUrl') as string);
+    this.parseOAuthFlowCommon(json, result);
+    return result;
+  }
+
+  private parseOpenIdConnectScheme(
+    json: JSONObject,
+    parent: SecuritySchemeParent,
+  ): OpenIdConnectScheme {
+    if (json.type !== 'openIdConnect') {
+      throw new Error(`Incorrent type value ${String(json.type)}`);
+    }
+    const result = new OpenIdConnectScheme(
+      parent,
+      getStringAttribute(json, 'openIdConnectUrl') as string,
+    );
+    this.parseSecuritySchemeCommon(json, result);
+    return result;
+  }
+
+  private parseCallback(json: JSONObject, parent: CallbackParent): Callback {
+    const result = new Callback(parent);
+    this.parseExtensionFields(result.extensions, json);
+    for (const [key, value] of Object.entries(json)) {
+      if (!key.startsWith('x-')) {
+        const pathItem = this.parsePathItem(value as JSONObject, result);
+        result.paths.set(key, pathItem);
+      }
+    }
+    return result;
+  }
+
+  private parsePathItem(json: JSONObject, parent: PathItemParent): PathItem {
+    const unknownMethods = Object.keys(json).filter(attr => {
+      return !attr.startsWith('x-') && !whitelistedProperties.includes(attr as HTTPMethod);
+    });
+    if (unknownMethods.length) {
+      throw new Error(
+        `Unsupported HTTP method(-s) ${unknownMethods.join(',')} ${JSON.stringify(json, null, 2)}`,
+      );
+    }
+
+    const result = new PathItem(parent);
+    this.parseExtensionFields(result.extensions, json);
+    result.summary = getStringAttribute(json, 'summary', false);
+    result.description = getStringAttribute(json, 'description', false);
+
+    for (const method of httpMethods) {
+      if (method in json) {
+        const operation = this.parseOperation(json[method] as JSONObject, result);
+        result.operations2.set(method, operation);
+      }
+    }
+    if ((json.servers as JSONObject[])?.length > 0) {
+      result.servers = (json.servers as ServerObject[]).map(itemJson =>
+        this.parseServer(itemJson, result),
+      );
+    }
+    if ((json.parameters as JSONObject[])?.length > 0) {
+      result.parameters = (json.parameters as JSONObject[]).map(parameterJson =>
+        this.parseParameter(parameterJson, result),
+      );
+    }
+    return result;
+  }
+
+  private parseOperation(json: JSONObject, parent: OperationParent): Operation {
+    if (json.responses && isEmpty(json.responses as JSONObject)) {
+      throw new Error(`Operation responses field cannot be empty`);
+    }
+
+    const result = new Operation(parent);
+    if (Array.isArray(json.tags)) {
+      json.tags.forEach(tag => result.tags.push(tag as string));
+    }
+    if (json.summary) {
+      result.summary = json.summary as string;
+    }
+    result.description = json.description as string;
+    if (json.externalDocs) {
+      result.externalDocs = this.parseExternalDocumentation(
+        json.externalDocs as JSONObject,
+        result,
+      );
+    }
+    if (json.operationId) {
+      result.operationId = json.operationId as string;
+    }
+    if ((json.parameters as JSONArray)?.length) {
+      for (const parameterJson of json.parameters as JSONArray) {
+        const parameter = this.parseParameter(parameterJson as JSONObject, result);
+        result.parameters.push(parameter);
+      }
+    }
+    if (json.requestBody) {
+      result.requestBody = this.parseRequestBody(json.requestBody as JSONObject, result);
+    }
+
+    for (const [key, responseJson] of Object.entries(json.responses as JSONObject)) {
+      const response = this.parseResponse(responseJson as JSONObject, result.responses);
+      if (key === 'default') {
+        result.responses.default = response;
+      } else {
+        result.responses.codes.set(key, response);
+      }
+    }
+
+    if (json.callbacks) {
+      for (const [callbackId, callbackJson] of Object.entries(json.callbacks)) {
+        const callback = this.parseCallback(callbackJson as JSONObject, result);
+        result.callbacks.set(callbackId, callback);
+      }
+    }
+    if ('security' in json) {
+      result.security = this.parseSecurityRequirement(
+        result,
+        json.security as SecurityRequirementObject[],
+      );
+    }
+    return result;
+  }
+
+  private parseExternalDocumentation(
+    json: JSONObject,
+    parent: ExternalDocumentationParent,
+  ): ExternalDocumentation {
+    const result = new ExternalDocumentation(parent, getStringAttribute(json, 'url') as string);
+    this.parseExtensionFields(result.extensions, json);
+    result.description = getStringAttribute(json, 'description', false);
+    return result;
+  }
+
+  private parseSecurityRequirement(
+    parent: SecurityRequirementParent,
+    json?: SecurityRequirementObject[],
+  ): Nullable<SecurityRequirement[]> {
+    if (!json) {
+      return null;
+    }
+    const result: SecurityRequirement[] = [];
+    for (const itemJson of json) {
+      const item = new SecurityRequirement(parent);
+      this.parseExtensionFields(item.extensions, itemJson);
+      for (const [schemeName, requiredScopes] of Object.entries(json)) {
+        assert(
+          !(
+            Array.isArray(requiredScopes) &&
+            (!requiredScopes.length || requiredScopes.every(s => typeof s === 'string'))
+          ),
+          'SeecurityRequirement scopes must be an array of strings',
+        );
+        item.scopes.set(schemeName, requiredScopes as unknown as string[]);
+      }
+      result.push(item);
+    }
+    return result;
+  }
+
+  private parseTag(json: JSONObject, parent: TagParent): Tag {
+    const result = new Tag(parent, getStringAttribute(json, 'name') as string);
+    this.parseExtensionFields(result.extensions, json);
+    result.description = getStringAttribute(json, 'description', false);
+    if (json.externalDocs) {
+      result.externalDocs = this.parseExternalDocumentation(
+        json.externalDocs as JSONObject,
+        result,
+      );
+    }
+    return result;
+  }
+
+  private parseDiscriminator(
+    json: DiscriminatorObject,
+    parent: DiscriminatorParent,
+  ): Discriminator {
+    const result = new Discriminator(parent, json.propertyName);
+    this.parseExtensionFields(result.extensions, json);
+    return result;
+  }
+
+  private parseXML(json: XMLObject, parent: XMLParent): XML {
+    const result = new XML(parent);
+    this.parseExtensionFields(result.extensions, json);
+    if (json.name) {
+      result.name = json.name;
+    }
+    if (json.namespace) {
+      result.namespace = json.namespace;
+    }
+    if (json.prefix) {
+      result.prefix = json.prefix;
+    }
+    result.attribute = json.attribute as boolean;
+    result.wrapped = json.wrapped as boolean;
+    return result;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import path from 'path';
+
+import yaml from 'yaml';
+
+import { MediaType } from './MediaType';
+import { OpenAPI } from './OpenAPI';
+import { OpenAPIReader } from './OpenAPIReader';
+import { OpenAPIWriter } from './OpenAPIWriter';
+
+import type { OpenAPIObject } from '../types';
+
+test('minimalistic schema', () => {
+  const openapi = new OpenAPI('Barebones', '1.2.3');
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject).toStrictEqual({
+    openapi: '3.0.3',
+    info: {
+      title: 'Barebones',
+      version: '1.2.3',
+    },
+    paths: {},
+  });
+});
+
+test('serialises Contact object', () => {
+  const openapi = new OpenAPI('Contact serialisation', '1.2.3');
+  openapi.info.contact.name = 'Maintainer';
+  openapi.info.contact.email = null;
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject.info.contact).toStrictEqual({
+    name: 'Maintainer',
+  });
+});
+
+test('serialises License object', () => {
+  const openapi = new OpenAPI('License serialisation', '0.1.1');
+  openapi.info.license.name = 'MIT';
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject.info.license).toStrictEqual({
+    name: 'MIT',
+  });
+});
+
+test('shared schemas + references', () => {
+  const openapi = new OpenAPI('Shared schema test', '0.1.0');
+
+  const errorSchema = openapi.components.setSchema('Error', 'object');
+  errorSchema.setProperty('code', { type: 'integer', required: true });
+
+  const errorListSchema = openapi.components.setSchema('ErrorList', 'array');
+  errorListSchema.items = errorSchema;
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject.components?.schemas).toStrictEqual({
+    Error: {
+      type: 'object',
+      required: ['code'],
+      properties: {
+        code: { type: 'integer' },
+      },
+    },
+    ErrorList: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/Error' },
+    },
+  });
+});
+
+test('serialises operation with inline schemas', () => {
+  const openapi = new OpenAPI('Operation test', '0.1.0');
+
+  const pathItem = openapi.setPathItem('/employees');
+  const operation = pathItem.addOperation('post');
+  const response = operation.responses.setDefaultResponse('Error response');
+  const responseMediaType = response.setContent('application/json') as MediaType;
+  const responseSchema = responseMediaType.setSchema('object');
+  responseSchema.setProperty('code', { type: 'integer', required: true });
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject.paths['/employees']).toStrictEqual({
+    post: {
+      responses: {
+        default: {
+          description: 'Error response',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['code'],
+                properties: {
+                  code: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+});
+
+test('serialises operation with shared schemas', () => {
+  const openapi = new OpenAPI('Operation test', '0.1.0');
+
+  const errorSchema = openapi.components.setSchema('Error', 'object');
+  errorSchema.setProperty('code', { type: 'integer', required: true });
+
+  const errorListSchema = openapi.components.setSchema('ErrorList', 'array');
+  errorListSchema.items = errorSchema;
+
+  const employeesPathItem = openapi.setPathItem('/employees');
+
+  const createEmployeeOperation = employeesPathItem.addOperation('post');
+  const createEmployeeResponse =
+    createEmployeeOperation.responses.setDefaultResponse('Error response');
+  const createEmployeeResponseJson = createEmployeeResponse.setContent('application/json');
+  createEmployeeResponseJson.schema = errorListSchema;
+
+  const writer = new OpenAPIWriter();
+  const openapiObject = writer.write(openapi);
+
+  expect(openapiObject.paths['/employees']).toStrictEqual({
+    post: {
+      responses: {
+        default: {
+          description: 'Error response',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorList',
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  expect(openapiObject.components?.schemas).toStrictEqual({
+    Error: {
+      type: 'object',
+      required: ['code'],
+      properties: {
+        code: { type: 'integer' },
+      },
+    },
+    ErrorList: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/Error' },
+    },
+  });
+});
+
+test.each(['api', 'callback', 'link', 'petstore', 'simple', 'uspto'])('example - %s', stem => {
+  const reader = new OpenAPIReader();
+
+  const inputText = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'examples', `${stem}.yaml`),
+    'utf-8',
+  );
+  const inputData = yaml.parse(inputText) as OpenAPIObject;
+
+  const openapi = reader.parse(inputData);
+
+  const writer = new OpenAPIWriter();
+  const outputData = writer.write(openapi);
+
+  expect(outputData).toStrictEqual(inputData);
+});

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
@@ -1,0 +1,953 @@
+import assert from 'assert';
+import fs from 'fs';
+
+import yaml from 'yaml';
+
+import type {
+  APIKeySecuritySchemeObject,
+  CallbackObject,
+  ComponentsObject,
+  ContactObject,
+  CookieParameterObject,
+  CookieParameterSerializationStyle,
+  ExampleObject,
+  ExternalDocumentationObject,
+  HTTPSecuritySchemeObject,
+  HeaderObject,
+  HeaderParameterObject,
+  InfoObject,
+  LicenseObject,
+  MediaTypeObject,
+  OpenAPIObject,
+  OperationObject,
+  ParameterObject,
+  PathItemObject,
+  PathParameterObject,
+  PathsObject,
+  QueryParameterObject,
+  RequestBodyObject,
+  ResponseObject,
+  ResponsesObject,
+  SchemaObject,
+  SecurityRequirementObject,
+  SecuritySchemeObject,
+  ServerObject,
+  ServerVariableObject,
+  TagObject,
+  OAuth2SecuritySchemeObject,
+  OpenIdConnectSecuritySchemeObject,
+  EncodingObject,
+  LinkObject,
+  ObjectOrRef,
+} from '../types';
+import type { ExtensionFields } from './BasicNode';
+import type { Callback } from './Callback';
+import type { Components } from './Components';
+import type { Contact } from './Contact';
+import type { Encoding } from './Encoding';
+import type { Example } from './Example';
+import type { ExternalDocumentation } from './ExternalDocumentation';
+import type { Header } from './Header';
+import type { Info } from './Info';
+import type { License } from './License';
+import type { Link, LinkParent } from './Link';
+import type { MediaType } from './MediaType';
+import type { OpenAPI } from './OpenAPI';
+import type { Operation } from './Operation';
+import type { Parameter } from './Parameter';
+import type { CookieParameter } from './Parameter/CookieParameter';
+import type { HeaderParameter } from './Parameter/HeaderParameter';
+import type { PathParameter } from './Parameter/PathParameter';
+import type { QueryParameter } from './Parameter/QueryParameter';
+import type { PathItem } from './PathItem';
+import type { Paths } from './Paths';
+import type { RequestBody } from './RequestBody';
+import type { Response } from './Response';
+import type { Responses } from './Responses';
+import type { Schema, SchemaParent } from './Schema';
+import type { SecurityRequirement } from './SecurityRequirement';
+import type { SecurityScheme } from './SecurityScheme';
+import type { ApiKeyScheme } from './SecurityScheme/ApiKeyScheme';
+import type { HttpScheme } from './SecurityScheme/HttpScheme';
+import type { OAuth2Scheme } from './SecurityScheme/OAuth2Scheme';
+import type { OpenIdConnectScheme } from './SecurityScheme/OpenIdConnectScheme';
+import type { Server } from './Server';
+import type { ServerVariable } from './ServerVariable';
+import type { Tag } from './Tag';
+import type { SchemaModel } from './types';
+
+export class OpenAPIWriter {
+  // maps OpenAPI schema objects to JSON pointers
+  readonly schemaPointers: Map<unknown, string>;
+
+  constructor() {
+    this.schemaPointers = new Map<unknown, string>();
+  }
+
+  writeToFile(schema: OpenAPI, fileName: string): void {
+    const openapiObject = this.write(schema);
+    const text = yaml.stringify(openapiObject);
+    fs.writeFileSync(fileName, text, 'utf-8');
+  }
+
+  write(schema: OpenAPI): OpenAPIObject {
+    this.collectSchemaPointers(schema);
+
+    const result: OpenAPIObject = {
+      openapi: '3.0.3',
+      info: this.writeInfo(schema.info),
+      paths: {},
+    };
+    this.writeExtensionFields(schema.extensions, result);
+    if (schema.servers.length) {
+      result.servers = schema.servers.map(arg => this.writeServer(arg));
+    }
+    if (!schema.components.isEmpty()) {
+      result.components = this.writeComponents(schema.components);
+    }
+    result.paths = this.writePaths(schema.paths);
+    if (schema.security) {
+      result.security = this.writeSecurityRequirementArray(schema.security);
+    }
+    if (schema.tags.length) {
+      result.tags = schema.tags.map(arg => this.writeTag(arg));
+    }
+    return result;
+  }
+
+  private collectSchemaPointers(openapi: OpenAPI): void {
+    this.schemaPointers.clear();
+
+    this.schemaPointers.set(openapi, '#/');
+    this.schemaPointers.set(openapi.info, '#/info');
+    this.schemaPointers.set(openapi.info.contact, '#/info/contact');
+    this.schemaPointers.set(openapi.info.license, '#/info/license');
+
+    this.schemaPointers.set(openapi.components, '#/components');
+    for (const [key, value] of openapi.components.schemas) {
+      this.schemaPointers.set(value, `#/components/schemas/${key}`);
+    }
+    for (const [key, value] of openapi.components.responses) {
+      this.schemaPointers.set(value, `#/components/responses/${key}`);
+    }
+    for (const [key, value] of openapi.components.parameters) {
+      this.schemaPointers.set(value, `#/components/parameters/${key}`);
+    }
+    for (const [key, value] of openapi.components.examples) {
+      this.schemaPointers.set(value, `#/components/examples/${key}`);
+    }
+    for (const [key, value] of openapi.components.requestBodies) {
+      this.schemaPointers.set(value, `#/components/requestBodies/${key}`);
+    }
+    for (const [key, value] of openapi.components.headers) {
+      this.schemaPointers.set(value, `#/components/headers/${key}`);
+    }
+    for (const [key, value] of openapi.components.securitySchemas) {
+      this.schemaPointers.set(value, `#/components/securitySchemas/${key}`);
+    }
+    for (const [key, value] of openapi.components.links) {
+      this.schemaPointers.set(value, `#/components/links/${key}`);
+    }
+    for (const [key, value] of openapi.components.callbacks) {
+      this.schemaPointers.set(value, `#/components/callbacks/${key}`);
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private writeExtensionFields(
+    extensionFields: ExtensionFields,
+    out: Record<string, unknown>,
+  ): void {
+    for (const [key, value] of extensionFields) {
+      out[key] = value;
+    }
+  }
+
+  private writeInfo(info: Info): InfoObject {
+    const result: InfoObject = {
+      title: info.title,
+      version: info.version,
+    };
+    this.writeExtensionFields(info.extensions, result);
+    if (info.description) {
+      result.description = info.description;
+    }
+    if (info.termsOfService) {
+      result.termsOfService = info.termsOfService;
+    }
+    const contact = this.writeContact(info.contact);
+    if (contact) {
+      result.contact = contact;
+    }
+    const license = this.writeLicense(info.license);
+    if (license) {
+      result.license = license;
+    }
+    return result;
+  }
+
+  private writeContact(contact: Contact): ContactObject | null {
+    const result: ContactObject = {};
+    this.writeExtensionFields(contact.extensions, result);
+    if (contact.name) {
+      result.name = contact.name;
+    }
+    if (contact.url) {
+      result.url = contact.url;
+    }
+    if (contact.email) {
+      result.email = contact.email;
+    }
+    return Object.keys(result).length ? result : null;
+  }
+
+  private writeLicense(license: License): LicenseObject | null {
+    if (license.name === 'UNLICENSED') {
+      return null;
+    }
+    const result: LicenseObject = { name: license.name };
+    this.writeExtensionFields(license.extensions, result);
+    if (license.url) {
+      result.url = license.url;
+    }
+    return result;
+  }
+
+  private writeServer(server: Server): ServerObject {
+    const result: ServerObject = { url: server.url };
+    this.writeExtensionFields(server.extensions, result);
+    if (server.description) {
+      result.description = server.description;
+    }
+    if (server.variables.size) {
+      result.variables = {};
+      for (const [key, value] of server.variables.entries()) {
+        result.variables[key] = this.writeServerVariable(value);
+      }
+    }
+    return result;
+  }
+
+  private writeServerVariable(serverVar: ServerVariable): ServerVariableObject {
+    const result: ServerVariableObject = { default: serverVar.default };
+    this.writeExtensionFields(serverVar.extensions, result);
+    if (serverVar.enum) {
+      result.enum = serverVar.enum;
+    }
+    if (serverVar.description) {
+      result.description = serverVar.description;
+    }
+    return result;
+  }
+
+  private writeComponents(components: Components): ComponentsObject {
+    const result: ComponentsObject = {};
+    this.writeExtensionFields(components.extensions, result);
+    if (components.schemas.size) {
+      result.schemas = {};
+      for (const [key, schema] of components.schemas) {
+        result.schemas[key] = this.writeSchema(schema, components);
+      }
+    }
+    if (components.responses.size) {
+      result.responses = {};
+      for (const [key, response] of components.responses) {
+        result.responses[key] = this.writeResponse(response);
+      }
+    }
+    if (components.parameters.size) {
+      result.parameters = {};
+      for (const [key, parameter] of components.parameters) {
+        result.parameters[key] = this.writeParameter(parameter);
+      }
+    }
+    if (components.examples.size) {
+      result.examples = {};
+      for (const [key, example] of components.examples) {
+        result.examples[key] = this.writeExample(example);
+      }
+    }
+    if (components.requestBodies.size) {
+      result.requestBodies = {};
+      for (const [key, requestBody] of components.requestBodies) {
+        result.requestBodies[key] = this.writeRequestBody(requestBody);
+      }
+    }
+    if (components.headers.size) {
+      result.headers = {};
+      for (const [key, header] of components.headers) {
+        result.headers[key] = this.writeHeader(header);
+      }
+    }
+    if (components.securitySchemas.size) {
+      result.securitySchemas = {};
+      for (const [key, securitySchemas] of components.securitySchemas) {
+        result.securitySchemas[key] = this.writeSecuritySchema(securitySchemas);
+      }
+    }
+    if (components.links.size) {
+      result.links = {};
+      for (const [key, link] of components.links) {
+        result.links[key] = this.writeLink(link, components);
+      }
+    }
+    if (components.callbacks.size) {
+      result.callbacks = {};
+      for (const [key, callback] of components.callbacks) {
+        result.callbacks[key] = this.writeCallback(callback);
+      }
+    }
+    return result;
+  }
+
+  private writeSchema(schema: SchemaModel, node?: SchemaParent): ObjectOrRef<SchemaObject> {
+    if (node !== (schema as Schema).parent) {
+      const pointer = this.schemaPointers.get(schema);
+      if (pointer) {
+        return { $ref: pointer };
+      }
+    }
+
+    const result: SchemaObject = {};
+    this.writeExtensionFields(schema.extensions as ExtensionFields, result);
+    if (schema.type) {
+      result.type = schema.type;
+    }
+    if (schema.title) {
+      result.title = schema.title;
+    }
+    if (schema.multipleOf != null) {
+      result.multipleOf = schema.multipleOf;
+    }
+    if (schema.maximum != null) {
+      result.maximum = schema.maximum;
+    }
+    if (schema.exclusiveMaximum === true) {
+      result.exclusiveMaximum = true;
+    }
+    if (schema.minimum != null) {
+      result.minimum = schema.minimum;
+    }
+    if (schema.exclusiveMinimum === true) {
+      result.exclusiveMinimum = schema.exclusiveMinimum;
+    }
+    if (schema.maxLength != null) {
+      result.maxLength = schema.maxLength;
+    }
+    if (schema.minLength != null) {
+      result.minLength = schema.minLength;
+    }
+    if (schema.pattern != null) {
+      result.pattern = schema.pattern;
+    }
+    if (schema.maxItems != null) {
+      result.maxItems = schema.maxItems;
+    }
+    if (schema.minItems != null) {
+      result.minItems = schema.minItems;
+    }
+    if (schema.uniqueItems === true) {
+      result.uniqueItems = true;
+    }
+    if (schema.maxProperties != null) {
+      result.maxProperties = schema.maxProperties;
+    }
+    if (schema.minProperties != null) {
+      result.minProperties = schema.minProperties;
+    }
+    if (schema.required.size) {
+      result.required = Array.from(schema.required);
+    }
+    if (schema.enum != null) {
+      result.enum = schema.enum;
+    }
+    if (schema.type != null) {
+      result.type = schema.type;
+    }
+    if (schema.allOf != null) {
+      result.allOf = schema.allOf.map((subschema: SchemaModel) => this.writeSchema(subschema));
+    }
+    if (schema.oneOf != null) {
+      result.oneOf = schema.oneOf.map((subschema: SchemaModel) => this.writeSchema(subschema));
+    }
+    if (schema.anyOf != null) {
+      result.anyOf = schema.anyOf.map((subschema: SchemaModel) => this.writeSchema(subschema));
+    }
+    if (schema.not != null) {
+      result.not = this.writeSchema(schema.not);
+    }
+    if (schema.items != null) {
+      result.items = this.writeSchema(schema.items);
+    }
+    if (schema.properties.size) {
+      result.properties = {};
+      for (const [key, value] of schema.properties) {
+        result.properties[key] = this.writeSchema(value);
+      }
+    }
+    if (schema.additionalProperties != null) {
+      if (typeof schema.additionalProperties !== 'boolean') {
+        result.additionalProperties = this.writeSchema(schema.additionalProperties);
+      } else if (schema.additionalProperties === false) {
+        result.additionalProperties = false;
+      }
+    }
+    if (schema.description) {
+      result.description = schema.description;
+    }
+    if (schema.format) {
+      result.format = schema.format;
+    }
+    if (schema.nullable) {
+      result.nullable = true;
+    }
+    if (schema.default != null) {
+      result.default = schema.default;
+    }
+    if (schema.example != null) {
+      result.example = schema.example;
+    }
+    return result;
+  }
+
+  private writeResponse(response: Response): ResponseObject {
+    const result: ResponseObject = { description: response.description };
+    this.writeExtensionFields(response.extensions, result);
+    if (response.headers.size) {
+      result.headers = {};
+      for (const [key, header] of response.headers) {
+        result.headers[key] = this.writeHeader(header);
+      }
+    }
+    if (response.content.size) {
+      result.content = {};
+      for (const [key, mediaType] of response.content) {
+        result.content[key] = this.writeMediaType(mediaType);
+      }
+    }
+    if (response.links.size) {
+      result.links = {};
+      for (const [key, link] of response.links) {
+        result.links[key] = this.writeLink(link, response);
+      }
+    }
+    return result;
+  }
+
+  private writeHeader(header: Header): HeaderObject {
+    const result: HeaderObject = {};
+    this.writeExtensionFields(header.extensions, result);
+    if (header.description) {
+      result.description = header.description;
+    }
+    if (header.required) {
+      result.required = true;
+    }
+    if (header.deprecated) {
+      result.deprecated = true;
+    }
+    if (header.style !== 'simple') {
+      result.style = header.style;
+    }
+    if (header.explode) {
+      result.explode = true;
+    }
+    if (header.schema) {
+      result.schema = this.writeSchema(header.schema);
+    }
+    if (header.example) {
+      result.example = header.example;
+    }
+    if (header.examples.size) {
+      result.examples = {};
+      for (const [key, example] of header.examples) {
+        result.examples[key] = this.writeExample(example);
+      }
+    }
+    if (header.content) {
+      result.content = {};
+      for (const [key, mediaType] of header.content) {
+        result.content[key] = this.writeMediaType(mediaType);
+      }
+    }
+    return result;
+  }
+
+  private writeExample(example: Example): ExampleObject {
+    const result: ExampleObject = {};
+    this.writeExtensionFields(example.extensions, result);
+    if (example.summary) {
+      result.summary = example.summary;
+    }
+    if (example.description) {
+      result.description = example.description;
+    }
+    if (example.value) {
+      result.value = example.value;
+    }
+    if (example.externalValue) {
+      result.externalValue = example.externalValue;
+    }
+    return result;
+  }
+
+  private writeMediaType(mediaType: MediaType): MediaTypeObject {
+    const result: MediaTypeObject = {};
+    this.writeExtensionFields(mediaType.extensions, result);
+    if (mediaType.schema) {
+      result.schema = this.writeSchema(mediaType.schema, mediaType);
+    }
+    if (mediaType.example) {
+      result.example = mediaType.example;
+    }
+    if (mediaType.examples.size) {
+      result.examples = {};
+      for (const [key, example] of mediaType.examples) {
+        result.examples[key] = this.writeExample(example);
+      }
+    }
+    if (mediaType.encoding.size) {
+      result.encoding = {};
+      for (const [key, encoding] of mediaType.encoding) {
+        result.encoding[key] = this.writeEncoding(encoding);
+      }
+    }
+    return result;
+  }
+
+  private writeEncoding(encoding: Encoding): EncodingObject {
+    const result: EncodingObject = {};
+    this.writeExtensionFields(encoding.extensions, result);
+    if (encoding.contentType) {
+      result.contentType = encoding.contentType;
+    }
+    if (encoding.headers.size) {
+      result.headers = {};
+      for (const [key, header] of encoding.headers) {
+        result.headers[key] = this.writeHeader(header);
+      }
+    }
+    if (encoding.style) {
+      result.style = encoding.style;
+    }
+    result.explode = encoding.explode;
+    result.allowReserved = encoding.allowReserved;
+    return result;
+  }
+
+  private writeLink(link: Link, node: LinkParent): ObjectOrRef<LinkObject> {
+    if (node !== link.parent) {
+      const pointer = this.schemaPointers.get(link);
+      if (pointer) {
+        return { $ref: pointer };
+      }
+    }
+
+    const result: LinkObject = {};
+    this.writeExtensionFields(link.extensions, result);
+    if (link.operationRef) {
+      result.operationRef = link.operationRef;
+    }
+    if (link.operationId) {
+      result.operationId = link.operationId;
+    }
+    if (link.parameters.size) {
+      result.parameters = Object.fromEntries(link.parameters.entries());
+    }
+    if (link.requestBody) {
+      result.requestBody = link.requestBody;
+    }
+    if (link.description) {
+      result.description = link.description;
+    }
+    if (link.server) {
+      result.server = this.writeServer(link.server);
+    }
+    return result;
+  }
+
+  private writeParameterCommon(parameter: PathParameter, result: PathParameterObject): void;
+  private writeParameterCommon(parameter: QueryParameter, result: QueryParameterObject): void;
+  private writeParameterCommon(parameter: HeaderParameter, result: HeaderParameterObject): void;
+  private writeParameterCommon(parameter: CookieParameter, result: CookieParameterObject): void;
+  private writeParameterCommon(
+    parameter: PathParameter | QueryParameter | HeaderParameter | CookieParameter,
+    result:
+      | PathParameterObject
+      | QueryParameterObject
+      | HeaderParameterObject
+      | CookieParameterObject,
+  ): void {
+    this.writeExtensionFields(parameter.extensions, result);
+    if (parameter.description) {
+      result.description = parameter.description;
+    }
+    if (parameter.deprecated) {
+      result.deprecated = true;
+    }
+    if (parameter.schema) {
+      result.schema = this.writeSchema(parameter.schema);
+    }
+    if (parameter.content.size) {
+      result.content = {};
+      for (const [key, mediaType] of parameter.content) {
+        result.content[key] = this.writeMediaType(mediaType);
+      }
+    }
+    if (parameter.example) {
+      result.example = parameter.example;
+    }
+    if (parameter.examples.size) {
+      result.examples = {};
+      for (const [key, example] of parameter.examples) {
+        result.examples[key] = this.writeExample(example);
+      }
+    }
+  }
+
+  private writePathParameter(param: PathParameter): PathParameterObject {
+    const result: PathParameterObject = { name: param.name, in: param.in, required: true };
+    this.writeParameterCommon(param, result);
+    if (param.style !== 'simple') {
+      result.style = param.style;
+    }
+    if (param.explode) {
+      result.explode = true;
+    }
+    return result;
+  }
+
+  private writeQueryParameter(param: QueryParameter): QueryParameterObject {
+    const result: QueryParameterObject = { name: param.name, in: param.in };
+    this.writeParameterCommon(param, result);
+    if (param.required) {
+      result.required = true;
+    }
+    if (param.style !== 'form') {
+      result.style = param.style;
+    }
+    if (param.explode !== (param.style === 'form')) {
+      result.explode = param.explode;
+    }
+    if (param.allowEmptyValue) {
+      result.allowEmptyValue = true;
+    }
+    if (param.allowReserved) {
+      result.allowReserved = true;
+    }
+    return result;
+  }
+
+  private writeHeaderParameter(param: HeaderParameter): HeaderParameterObject {
+    const result: HeaderParameterObject = { name: param.name, in: param.in };
+    this.writeParameterCommon(param, result);
+    if (param.required) {
+      result.required = true;
+    }
+    if (param.style !== 'simple') {
+      result.style = param.style;
+    }
+    if (!param.explode) {
+      result.explode = false;
+    }
+    return result;
+  }
+
+  private writeCookieParameter(param: CookieParameter): CookieParameterObject {
+    const result: CookieParameterObject = { name: param.name, in: param.in };
+    this.writeParameterCommon(param, result);
+    if (param.required) {
+      result.required = true;
+    }
+    if (param.style !== 'form') {
+      result.style = param.style as CookieParameterSerializationStyle;
+    }
+    if (param.explode !== (param.style === 'form')) {
+      result.explode = param.explode;
+    }
+    return result;
+  }
+
+  // eslint-disable-next-line consistent-return
+  private writeParameter(parameter: Parameter): ParameterObject {
+    switch (parameter.in) {
+      case 'path':
+        return this.writePathParameter(parameter);
+      case 'query':
+        return this.writeQueryParameter(parameter);
+      case 'header':
+        return this.writeHeaderParameter(parameter);
+      case 'cookie':
+        return this.writeCookieParameter(parameter);
+      default:
+        assert.fail(
+          `Unsupported parameter type ${String((parameter as Record<string, string>).in)}`,
+        );
+    }
+  }
+
+  private writeRequestBody(requestBody: RequestBody): RequestBodyObject {
+    const result: RequestBodyObject = {
+      content: {},
+    };
+    this.writeExtensionFields(requestBody.extensions, result);
+    if (requestBody.description) {
+      result.description = requestBody.description;
+    }
+    if (requestBody.content.size) {
+      result.content = {};
+      for (const [key, mediaType] of requestBody.content) {
+        result.content[key] = this.writeMediaType(mediaType);
+      }
+    }
+    if (requestBody.required) {
+      result.required = true;
+    }
+    return result;
+  }
+
+  private writeSecuritySchemaCommon(
+    scheme: ApiKeyScheme | HttpScheme | OAuth2Scheme | OpenIdConnectScheme,
+    result:
+      | APIKeySecuritySchemeObject
+      | HTTPSecuritySchemeObject
+      | OAuth2SecuritySchemeObject
+      | OpenIdConnectSecuritySchemeObject,
+  ): void {
+    this.writeExtensionFields(scheme.extensions, result);
+    if (scheme.description) {
+      result.description = scheme.description;
+    }
+  }
+
+  private writeApiKeySecuritySchema(scheme: ApiKeyScheme): APIKeySecuritySchemeObject {
+    const result: APIKeySecuritySchemeObject = {
+      type: scheme.type,
+      name: scheme.name,
+      in: scheme.in,
+    };
+    this.writeSecuritySchemaCommon(scheme, result);
+    return result;
+  }
+
+  private writeHttpSecuritySchema(scheme: HttpScheme): HTTPSecuritySchemeObject {
+    const result: HTTPSecuritySchemeObject = {
+      type: scheme.type,
+      scheme: this.writeSchema(scheme.scheme),
+    };
+    this.writeSecuritySchemaCommon(scheme, result);
+    if (scheme.bearerFormat) {
+      result.bearerFormat = scheme.bearerFormat;
+    }
+    return result;
+  }
+
+  private writeOAuth2SecuritySchema(scheme: OAuth2Scheme): OAuth2SecuritySchemeObject {
+    const result: OAuth2SecuritySchemeObject = { type: scheme.type, flows: {} };
+    this.writeSecuritySchemaCommon(scheme, result);
+    if (scheme.flows.authorizationCode) {
+      result.flows.authorizationCode = {
+        scopes: Object.fromEntries(scheme.flows.authorizationCode.scopes.entries()),
+        authorizationUrl: scheme.flows.authorizationCode.authorizationUrl,
+        tokenUrl: scheme.flows.authorizationCode.tokenUrl,
+      };
+    }
+    if (scheme.flows.clientCredentials) {
+      result.flows.clientCredentials = {
+        scopes: Object.fromEntries(scheme.flows.clientCredentials.scopes.entries()),
+        tokenUrl: scheme.flows.clientCredentials.tokenUrl,
+      };
+    }
+    if (scheme.flows.implicit) {
+      result.flows.implicit = {
+        scopes: Object.fromEntries(scheme.flows.implicit.scopes.entries()),
+        authorizationUrl: scheme.flows.implicit.authorizationUrl,
+      };
+    }
+    if (scheme.flows.password) {
+      result.flows.password = {
+        scopes: Object.fromEntries(scheme.flows.password.scopes.entries()),
+        tokenUrl: scheme.flows.password.tokenUrl,
+      };
+    }
+    return result;
+  }
+
+  private writeOpenIdConnectSecuritySchema(
+    scheme: OpenIdConnectScheme,
+  ): OpenIdConnectSecuritySchemeObject {
+    const result: OpenIdConnectSecuritySchemeObject = {
+      type: scheme.type,
+      openIdConnectUrl: scheme.openIdConnectUrl,
+    };
+    this.writeSecuritySchemaCommon(scheme, result);
+    return result;
+  }
+
+  private writeSecuritySchema(securitySchema: SecurityScheme): SecuritySchemeObject {
+    switch (securitySchema.type) {
+      case 'apiKey':
+        return this.writeApiKeySecuritySchema(securitySchema);
+      case 'http':
+        return this.writeHttpSecuritySchema(securitySchema);
+      case 'oauth2':
+        return this.writeOAuth2SecuritySchema(securitySchema);
+      case 'openIdConnect':
+        return this.writeOpenIdConnectSecuritySchema(securitySchema);
+      default:
+        throw new Error(`Unsupported security schema type ${String(securitySchema)}`);
+    }
+  }
+
+  private writeCallback(callback: Callback): CallbackObject {
+    const result: CallbackObject = {};
+    this.writeExtensionFields(callback.extensions, result);
+    for (const [expr, pathItem] of callback.paths) {
+      result[expr] = this.writePathItem(pathItem);
+    }
+    return result;
+  }
+
+  private writePathItem(pathItem: PathItem): PathItemObject {
+    const result: PathItemObject = {};
+    this.writeExtensionFields(pathItem.extensions, result);
+    if (pathItem.summary) {
+      result.summary = pathItem.summary;
+    }
+    if (pathItem.description) {
+      result.description = pathItem.description;
+    }
+    for (const [operName, operDesc] of pathItem.operations2) {
+      result[operName] = this.writeOperation(operDesc);
+    }
+    if (pathItem.servers.length) {
+      result.servers = pathItem.servers.map(arg => this.writeServer(arg));
+    }
+    if (pathItem.parameters.length) {
+      result.parameters = pathItem.parameters.map(arg => this.writeParameter(arg));
+    }
+    return result;
+  }
+
+  private writeOperation(operation: Operation): OperationObject {
+    const result: OperationObject = {
+      responses: this.writeResponses(operation.responses),
+    };
+    this.writeExtensionFields(operation.extensions, result);
+    if (operation.tags.length) {
+      result.tags = operation.tags;
+    }
+    if (operation.summary) {
+      result.summary = operation.summary;
+    }
+    if (operation.description) {
+      result.description = operation.description;
+    }
+    if (operation.externalDocs) {
+      result.externalDocumentation = this.writeExternalDocs(operation.externalDocs);
+    }
+    if (operation.operationId) {
+      result.operationId = operation.operationId;
+    }
+    if (operation.parameters.length) {
+      result.parameters = operation.parameters.map(arg => this.writeParameter(arg));
+    }
+    if (operation.requestBody) {
+      result.requestBody = this.writeRequestBody(operation.requestBody);
+    }
+    if (operation.callbacks.size) {
+      result.callbacks = {};
+      for (const [name, callback] of operation.callbacks) {
+        result.callbacks[name] = this.writeCallback(callback);
+      }
+    }
+    if (operation.deprecated) {
+      result.deprecated = operation.deprecated;
+    }
+    if (operation.security) {
+      result.security = this.writeSecurityRequirementArray(operation.security);
+    }
+    if (operation.servers.length) {
+      result.servers = operation.servers.map(arg => this.writeServer(arg));
+    }
+    return result;
+  }
+
+  private writeExternalDocs(externalDocs: ExternalDocumentation): ExternalDocumentationObject {
+    const result: ExternalDocumentationObject = { url: externalDocs.url };
+    this.writeExtensionFields(externalDocs.extensions, result);
+    if (externalDocs.description) {
+      result.description = externalDocs.description;
+    }
+    return result;
+  }
+
+  private writeResponses(responses: Responses): ResponsesObject {
+    const result: ResponsesObject = {};
+    this.writeExtensionFields(responses.extensions, result);
+    if (responses.codes.size) {
+      for (const [httpStatus, response] of responses.codes) {
+        result[Number(httpStatus)] = this.writeResponse(response);
+      }
+    }
+    if (responses.default) {
+      result.default = this.writeResponse(responses.default);
+    }
+    return result;
+  }
+
+  private writeSecurityRequirementArray(
+    security: SecurityRequirement[],
+  ): SecurityRequirementObject[] {
+    return security.map(item => this.writeSecurityRequirement(item));
+  }
+
+  private writeSecurityRequirement(securityItem: SecurityRequirement): SecurityRequirementObject {
+    const result: SecurityRequirementObject = {};
+    this.writeExtensionFields(securityItem.extensions, result);
+    for (const [key, scopes] of securityItem.scopes) {
+      result[key] = scopes;
+    }
+    return result;
+  }
+
+  private writePaths(paths: Paths): PathsObject {
+    const result: PathsObject = {};
+    this.writeExtensionFields(paths.extensions, result);
+    for (const [pathUrlExp, pathItem] of paths) {
+      result[pathUrlExp] = this.writePathItem(pathItem);
+    }
+    return result;
+  }
+
+  private writeTag(tag: Tag): TagObject {
+    const result: TagObject = { name: tag.name };
+    if (tag.description) {
+      result.description = tag.description;
+    }
+    if (tag.externalDocs) {
+      result.externalDocs = this.writeExternalDocs(tag.externalDocs);
+    }
+    this.writeExtensionFields(tag.extensions, result);
+    return result;
+  }
+
+  // dumpXML(xml: XML): JSONObject {
+  //   const result = this.writeExtensionFields(xml.extensionFields);
+  //   result.name = xml.name;
+  //   result.namespace = xml.namespace;
+  //   result.prefix = xml.prefix;
+  //   result.attribute = xml.attribute;
+  //   result.wrapped = xml.wrapped;
+  //   return result;
+  // }
+
+  // dumpDiscriminator(discriminator: Discriminator): JSONValue {
+  //   const result = this.writeExtensionFields(discriminator.extensionFields);
+  //   result.propertyName = discriminator.propertyName;
+  //   if (discriminator.mapping.size) {
+  //     result.mapping = Object.fromEntries(discriminator.mapping.entries());
+  //   }
+  //   return result;
+  // }
+}

--- a/packages/openapi-model/src/3.0.3/model/Operation.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.ts
@@ -1,0 +1,122 @@
+import assert from 'assert';
+
+import { BasicNode } from './BasicNode';
+import {
+  PathParameter,
+  QueryParameter,
+  HeaderParameter,
+  CookieParameter,
+  Parameter,
+} from './Parameter';
+import { Responses } from './Responses';
+
+import type { Callback } from './Callback';
+import type { ExternalDocumentation } from './ExternalDocumentation';
+import type { PathItem } from './PathItem';
+import type { RequestBody } from './RequestBody';
+import type { SecurityRequirement } from './SecurityRequirement';
+import type { Server } from './Server';
+import type { OperationModel, ParameterLocation } from './types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+export type OperationParent = PathItem;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#operation-object
+ */
+export class Operation extends BasicNode<OperationParent> implements OperationModel {
+  readonly tags: string[];
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  externalDocs: Nullable<ExternalDocumentation>;
+  operationId: Nullable<string>;
+  readonly parameters: Parameter[];
+  requestBody: Nullable<RequestBody>;
+  readonly responses: Responses;
+  readonly callbacks: Map<string, Callback>;
+  deprecated: boolean;
+  security: Nullable<SecurityRequirement[]>;
+  readonly servers: Server[];
+
+  constructor(parent: OperationParent) {
+    super(parent);
+    this.tags = [];
+    this.summary = null;
+    this.description = null;
+    this.externalDocs = null;
+    this.operationId = null;
+    this.parameters = [];
+    this.requestBody = null;
+    this.responses = new Responses(this);
+    this.callbacks = new Map<string, Callback>();
+    this.deprecated = false;
+    this.security = null;
+    this.servers = [];
+  }
+
+  addParameter(name: string, location: 'path'): PathParameter;
+  addParameter(name: string, location: 'query'): QueryParameter;
+  addParameter(name: string, location: 'header'): HeaderParameter;
+  addParameter(name: string, location: 'cookie'): CookieParameter;
+  // eslint-disable-next-line consistent-return
+  addParameter(name: string, location: ParameterLocation): Parameter {
+    switch (location) {
+      case 'path': {
+        const param = new PathParameter(this, name);
+        this.parameters.push(param);
+        return param;
+      }
+      case 'query': {
+        const param = new QueryParameter(this, name);
+        this.parameters.push(param);
+        return param;
+      }
+      case 'header': {
+        const param = new HeaderParameter(this, name);
+        this.parameters.push(param);
+        return param;
+      }
+      case 'cookie': {
+        const param = new CookieParameter(this, name);
+        this.parameters.push(param);
+        return param;
+      }
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        assert.fail(`Unexpected parameter type ${location}`);
+    }
+  }
+
+  deleteParameter(name: string): void {
+    const i = this.parameters.findIndex(p => p.name === name);
+    if (i >= 0) {
+      this.parameters.splice(i, 1);
+    }
+  }
+
+  clearParameters(): void {
+    this.parameters.splice(0, this.parameters.length);
+  }
+
+  addTag(name: string): void {
+    if (this.tags.includes(name)) {
+      throw new Error(`Duplicate tag ${name}`);
+    }
+    this.tags.push(name);
+  }
+
+  deleteTag(name: string): void {
+    const index = this.tags.indexOf(name);
+    if (index >= 0) {
+      this.deleteTagAt(index);
+    }
+  }
+
+  deleteTagAt(index: number): void {
+    this.tags.splice(index, 1);
+  }
+
+  clearTags(): void {
+    this.tags.splice(0, this.tags.length);
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.ts
@@ -1,0 +1,23 @@
+import { Parameter, ParameterParent } from './Parameter';
+import { defaultExplode, defaultRequired, defaultSerializationStyles } from './utils';
+
+import type { CookieParameterModel } from '../types';
+
+export type SerializationStyle = 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export class CookieParameter extends Parameter implements CookieParameterModel {
+  style: SerializationStyle;
+  explode: boolean;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, 'cookie', name);
+    this.required = defaultRequired.cookie;
+    this.style = defaultSerializationStyles.cookie as SerializationStyle;
+    this.explode = defaultExplode[this.style];
+  }
+
+  declare readonly in: 'cookie';
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.ts
@@ -1,0 +1,23 @@
+import { Parameter, ParameterParent } from './Parameter';
+import { defaultExplode, defaultRequired, defaultSerializationStyles } from './utils';
+
+import type { HeaderParameterModel } from '../types';
+
+export type SerializationStyle = 'simple';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export class HeaderParameter extends Parameter implements HeaderParameterModel {
+  style: SerializationStyle;
+  explode: boolean;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, 'header', name);
+    this.required = defaultRequired.header;
+    this.style = defaultSerializationStyles.header as SerializationStyle;
+    this.explode = defaultExplode[this.style];
+  }
+
+  declare readonly in: 'header';
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/Parameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/Parameter.ts
@@ -1,0 +1,40 @@
+import { BasicNode } from '../BasicNode';
+
+import type { Components } from '../Components';
+import type { Example } from '../Example';
+import type { MediaType } from '../MediaType';
+import type { Operation } from '../Operation';
+import type { PathItem } from '../PathItem';
+import type { Schema } from '../Schema';
+import type { ParameterLocation } from '../types';
+import type { JSONValue, Nullable } from '@fresha/api-tools-core';
+
+export type ParameterParent = Components | PathItem | Operation;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export class Parameter extends BasicNode<ParameterParent> {
+  readonly in: ParameterLocation;
+  readonly name: string;
+  description: Nullable<string>;
+  deprecated: boolean;
+  schema: Nullable<Schema>;
+  readonly content: Map<string, MediaType>;
+  example: JSONValue;
+  readonly examples: Map<string, Example>;
+  required: boolean;
+
+  constructor(parent: ParameterParent, location: ParameterLocation, name: string) {
+    super(parent);
+    this.name = name;
+    this.in = location;
+    this.description = null;
+    this.deprecated = false;
+    this.schema = null;
+    this.content = new Map<string, MediaType>();
+    this.example = null;
+    this.examples = new Map<string, Example>();
+    this.required = false;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.ts
@@ -1,0 +1,24 @@
+import { Parameter, ParameterParent } from './Parameter';
+import { defaultExplode } from './utils';
+
+import type { PathParameterSerializationStyle } from '../../types';
+import type { PathParameterModel } from '../types';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export class PathParameter extends Parameter implements PathParameterModel {
+  style: PathParameterSerializationStyle;
+  explode: boolean;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, 'path', name);
+    this.required = true;
+    this.style = 'simple';
+    this.explode = defaultExplode[this.style];
+    this.required = true;
+  }
+
+  declare readonly in: 'path';
+  declare readonly required: true;
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.ts
@@ -1,0 +1,25 @@
+import { Parameter, ParameterParent } from './Parameter';
+import { defaultRequired, defaultExplode } from './utils';
+
+import type { QueryParameterModel, QueryParameterSerializationStyle } from '../types';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export class QueryParameter extends Parameter implements QueryParameterModel {
+  allowEmptyValue: boolean;
+  style: QueryParameterSerializationStyle;
+  explode: boolean;
+  allowReserved: boolean;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, 'query', name);
+    this.required = defaultRequired.query;
+    this.allowEmptyValue = false; // since it is deprecated, always set to false
+    this.style = 'form';
+    this.explode = defaultExplode[this.style];
+    this.allowReserved = false;
+  }
+
+  declare readonly in: 'query';
+}

--- a/packages/openapi-model/src/3.0.3/model/Parameter/index.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/index.ts
@@ -1,0 +1,10 @@
+import { CookieParameter } from './CookieParameter';
+import { HeaderParameter } from './HeaderParameter';
+import { PathParameter } from './PathParameter';
+import { QueryParameter } from './QueryParameter';
+
+export { ParameterParent } from './Parameter';
+
+export type Parameter = CookieParameter | HeaderParameter | PathParameter | QueryParameter;
+
+export { CookieParameter, HeaderParameter, PathParameter, QueryParameter };

--- a/packages/openapi-model/src/3.0.3/model/Parameter/utils.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/utils.ts
@@ -1,0 +1,23 @@
+export const defaultRequired: Record<string, boolean> = {
+  query: false,
+  header: false,
+  path: true,
+  cookie: false,
+};
+
+export const defaultSerializationStyles: Record<string, string> = {
+  query: 'form',
+  path: 'simple',
+  header: 'simple',
+  cookie: 'form',
+};
+
+export const defaultExplode: Record<string, boolean> = {
+  matrix: false,
+  label: false,
+  form: true,
+  simple: false,
+  spaceDelimited: false,
+  pipeDelimited: false,
+  deepObject: false,
+};

--- a/packages/openapi-model/src/3.0.3/model/PathItem.ts
+++ b/packages/openapi-model/src/3.0.3/model/PathItem.ts
@@ -1,0 +1,127 @@
+import { BasicNode } from './BasicNode';
+import { Operation } from './Operation';
+
+import type { Callback } from './Callback';
+import type { Parameter } from './Parameter';
+import type { Paths } from './Paths';
+import type { Server } from './Server';
+import type { PathItemModel, OperationModel, HTTPMethod } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export const httpMethods: HTTPMethod[] = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+];
+
+export const whitelistedProperties = [
+  ...httpMethods,
+  '$ref',
+  'summary',
+  'description',
+  'servers',
+  'parameters',
+];
+
+export type PathItemParent = Paths | Callback;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#path-item-object
+ */
+export class PathItem extends BasicNode<PathItemParent> implements PathItemModel {
+  summary: Nullable<string>;
+  description: Nullable<string>;
+  readonly operations2: Map<HTTPMethod, Operation>;
+  servers: Server[];
+  parameters: Parameter[];
+
+  constructor(parent: PathItemParent) {
+    super(parent);
+    this.summary = null;
+    this.description = null;
+    this.operations2 = new Map<HTTPMethod, Operation>();
+    this.servers = [];
+    this.parameters = [];
+  }
+
+  *operations(): IterableIterator<[HTTPMethod, OperationModel]> {
+    if (this.get) {
+      yield ['get', this.get];
+    }
+    if (this.put) {
+      yield ['put', this.put];
+    }
+    if (this.post) {
+      yield ['post', this.post];
+    }
+    if (this.delete) {
+      yield ['delete', this.delete];
+    }
+    if (this.options) {
+      yield ['options', this.options];
+    }
+    if (this.head) {
+      yield ['head', this.head];
+    }
+    if (this.patch) {
+      yield ['patch', this.patch];
+    }
+    if (this.trace) {
+      yield ['trace', this.trace];
+    }
+  }
+
+  get get(): Nullable<OperationModel> {
+    return this.operations2.get('get') ?? null;
+  }
+
+  get put(): Nullable<OperationModel> {
+    return this.operations2.get('put') ?? null;
+  }
+
+  get post(): Nullable<OperationModel> {
+    return this.operations2.get('post') ?? null;
+  }
+
+  get delete(): Nullable<OperationModel> {
+    return this.operations2.get('delete') ?? null;
+  }
+
+  get options(): Nullable<OperationModel> {
+    return this.operations2.get('options') ?? null;
+  }
+
+  get head(): Nullable<OperationModel> {
+    return this.operations2.get('head') ?? null;
+  }
+
+  get patch(): Nullable<OperationModel> {
+    return this.operations2.get('patch') ?? null;
+  }
+
+  get trace(): Nullable<OperationModel> {
+    return this.operations2.get('trace') ?? null;
+  }
+
+  addOperation(method: HTTPMethod): OperationModel {
+    if (this.operations2.has(method)) {
+      throw new Error(`Duplicate ${method} operation`);
+    }
+    const operation = new Operation(this);
+    this.operations2.set(method, operation);
+    return operation;
+  }
+
+  removeOperation(method: HTTPMethod): void {
+    this.operations2.delete(method);
+  }
+
+  clearOperations(): void {
+    this.operations2.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Paths.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.ts
@@ -1,0 +1,71 @@
+import { BasicNode } from './BasicNode';
+
+import type { OpenAPI } from './OpenAPI';
+import type { PathItem } from './PathItem';
+import type { ParametrisedURLString, PathsModel } from './types';
+
+export type PathsParent = OpenAPI;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#paths-object
+ */
+export class Paths extends BasicNode<PathsParent> implements PathsModel {
+  items: Map<ParametrisedURLString, PathItem>;
+
+  constructor(parent: OpenAPI) {
+    super(parent);
+    this.items = new Map<ParametrisedURLString, PathItem>();
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  delete(key: string): boolean {
+    return this.items.delete(key);
+  }
+
+  forEach(
+    callbackfn: (value: PathItem, key: string, map: Map<string, PathItem>) => void,
+    thisArg?: unknown,
+  ): void {
+    this.items.forEach(callbackfn, thisArg);
+  }
+
+  get(key: string): PathItem | undefined {
+    return this.items.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.items.has(key);
+  }
+
+  set(key: string, value: PathItem): this {
+    this.items.set(key, value);
+    return this;
+  }
+
+  get size(): number {
+    return this.items.size;
+  }
+
+  entries(): IterableIterator<[string, PathItem]> {
+    return this.items.entries();
+  }
+
+  keys(): IterableIterator<string> {
+    return this.items.keys();
+  }
+
+  values(): IterableIterator<PathItem> {
+    return this.items.values();
+  }
+
+  [Symbol.iterator](): IterableIterator<[string, PathItem]> {
+    return this.items.entries();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.items[Symbol.toStringTag];
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/RequestBody.ts
+++ b/packages/openapi-model/src/3.0.3/model/RequestBody.ts
@@ -1,0 +1,39 @@
+import { BasicNode } from './BasicNode';
+import { MediaType } from './MediaType';
+
+import type { Components } from './Components';
+import type { Operation } from './Operation';
+import type { MIMETypeString, RequestBodyModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type RequestBodyParent = Components | Operation;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#request-body-object
+ */
+export class RequestBody extends BasicNode<RequestBodyParent> implements RequestBodyModel {
+  description: Nullable<string>;
+  readonly content: Map<MIMETypeString, MediaType>;
+  required: boolean;
+
+  constructor(parent: RequestBodyParent) {
+    super(parent);
+    this.description = null;
+    this.content = new Map<string, MediaType>();
+    this.required = false;
+  }
+
+  setContent(mimeType: MIMETypeString): MediaType {
+    const result = new MediaType(this);
+    this.content.set(mimeType, result);
+    return result;
+  }
+
+  deleteContent(mimeType: MIMETypeString): void {
+    this.content.delete(mimeType);
+  }
+
+  clearContent(): void {
+    this.content.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Response.ts
+++ b/packages/openapi-model/src/3.0.3/model/Response.ts
@@ -1,0 +1,45 @@
+import { BasicNode } from './BasicNode';
+import { MediaType } from './MediaType';
+
+import type { Components } from './Components';
+import type { Header } from './Header';
+import type { Link } from './Link';
+import type { Responses } from './Responses';
+import type { MediaTypeModel, MIMETypeString, ResponseModel } from './types';
+
+export type ResponseParent = Components | Responses;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#response-object
+ */
+export class Response extends BasicNode<ResponseParent> implements ResponseModel {
+  description: string;
+  readonly headers: Map<string, Header>;
+  readonly content: Map<MIMETypeString, MediaType>;
+  readonly links: Map<string, Link>;
+
+  constructor(parent: ResponseParent, description: string) {
+    super(parent);
+    this.description = description;
+    this.headers = new Map<string, Header>();
+    this.content = new Map<string, MediaType>();
+    this.links = new Map<string, Link>();
+  }
+
+  setContent(mimeType: MIMETypeString): MediaTypeModel {
+    if (this.content.has(mimeType)) {
+      throw new Error(`Duplicate content for ${mimeType}`);
+    }
+    const result = new MediaType(this);
+    this.content.set(mimeType, result);
+    return result;
+  }
+
+  deleteContent(mimeType: MIMETypeString): void {
+    this.content.delete(mimeType);
+  }
+
+  clearContent(): void {
+    this.content.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Responses.ts
+++ b/packages/openapi-model/src/3.0.3/model/Responses.ts
@@ -1,0 +1,49 @@
+import { BasicNode } from './BasicNode';
+import { Response } from './Response';
+
+import type { Operation } from './Operation';
+import type { HTTPStatusCode, ResponseModel, ResponsesModel } from './types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+export type ResponsesParent = Operation;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#responses-object
+ */
+export class Responses extends BasicNode<ResponsesParent> implements ResponsesModel {
+  default: Nullable<Response>;
+  codes: Map<HTTPStatusCode, Response>;
+
+  constructor(parent: ResponsesParent) {
+    super(parent);
+    this.default = null; // new Response(this, 'Default');
+    this.codes = new Map<HTTPStatusCode, Response>();
+  }
+
+  setDefaultResponse(description: string): ResponseModel {
+    const response = new Response(this, description);
+    this.default = response;
+    return response;
+  }
+
+  deleteDefaultResponse(): void {
+    this.default = null;
+  }
+
+  setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel {
+    if (this.codes.has(code)) {
+      throw new Error(`Duplicate response for code ${code}`);
+    }
+    const response = new Response(this, description);
+    this.codes.set(code, response);
+    return response;
+  }
+
+  deleteResponse(code: HTTPStatusCode): void {
+    this.codes.delete(code);
+  }
+
+  clearResponses(): void {
+    this.codes.clear();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -1,0 +1,204 @@
+import { OpenAPI } from './OpenAPI';
+import { Schema, SchemaFactory } from './Schema';
+
+describe('SchemaFactory', () => {
+  test('create()', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const booleanSchema = SchemaFactory.create(openapi.components, 'boolean') as Schema;
+    expect(booleanSchema.parent).toBe(openapi.components);
+    expect(booleanSchema.type).toBe('boolean');
+
+    const genericIntegerSchema = SchemaFactory.create(openapi.components, 'integer');
+    expect(genericIntegerSchema.type).toBe('integer');
+    expect(genericIntegerSchema.format).toBeNull();
+
+    const int32Schema = SchemaFactory.create(openapi.components, 'int32');
+    expect(int32Schema.type).toBe('integer');
+    expect(int32Schema.format).toBe('int32');
+
+    const dateTimeSchema = SchemaFactory.create(openapi.components, 'date-time');
+    expect(dateTimeSchema.type).toBe('string');
+    expect(dateTimeSchema.format).toBe('date-time');
+  });
+
+  test('createArray()', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const stringArraySchema = SchemaFactory.createArray(openapi.components, 'string') as Schema;
+    expect(stringArraySchema.parent).toBe(openapi.components);
+    expect(stringArraySchema.minItems).toBeNull();
+    expect(stringArraySchema.maxItems).toBeNull();
+    expect(stringArraySchema.items?.type).toBe('string');
+
+    const numberArraySchema = SchemaFactory.createArray(openapi.components, {
+      type: 'number',
+      minItems: 10,
+      maxItems: 12,
+    });
+    expect(numberArraySchema.minItems).toBe(10);
+    expect(numberArraySchema.maxItems).toBe(12);
+
+    const itemSchema = SchemaFactory.create(openapi.components, 'integer') as Schema;
+    const integerArraySchema = SchemaFactory.createArray(openapi.components, itemSchema);
+    expect(itemSchema.parent).toBe(openapi.components);
+    expect(integerArraySchema.items).toBe(itemSchema);
+  });
+
+  test('createObject()', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const emptyObjectSchema = SchemaFactory.createObject(openapi.components, {}) as Schema;
+    expect(emptyObjectSchema.parent).toBe(openapi.components);
+    expect(emptyObjectSchema.properties).toHaveProperty('size', 0);
+    expect(emptyObjectSchema.required.size).toBe(0);
+
+    const objectSchema = SchemaFactory.createObject(openapi.components, {
+      name: 'string',
+      age: { type: 'int32', required: true },
+      active: { type: 'boolean', required: true },
+    });
+    expect(objectSchema.properties).toHaveProperty('size', 3);
+    expect(objectSchema.properties.get('name')?.type).toBe('string');
+    expect(objectSchema.properties.get('age')?.type).toBe('integer');
+    expect(objectSchema.required).toStrictEqual(new Set<string>(['age', 'active']));
+  });
+});
+
+describe('Schema', () => {
+  test('setProperty', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'object');
+    expect(schema.properties.size).toBe(0);
+    expect(schema.required.size).toBe(0);
+
+    const optionalProp = schema.setProperty('x', 'int32') as Schema;
+    expect(optionalProp.parent).toBe(schema);
+    expect(optionalProp.type).toBe('integer');
+    expect(optionalProp.format).toBe('int32');
+    expect(schema.properties.get('x')).toBe(optionalProp);
+    expect(schema.required.size).toBe(0);
+
+    const requiredProp = schema.setProperty('y', { type: 'date', required: true }) as Schema;
+    expect(requiredProp.parent).toBe(schema);
+    expect(schema.required.has('y')).toBe(true);
+  });
+
+  test('setProperties', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'object');
+    schema.setProperties({
+      x: 'string',
+      y: 'int32',
+      z: { type: 'boolean', required: true },
+    });
+    expect(schema.properties.size).toBe(3);
+    expect(schema.required).toStrictEqual(new Set<string>(['z']));
+  });
+
+  test('deleteProperty', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'object');
+    schema.setProperties({
+      x: 'string',
+      y: 'int32',
+      z: { type: 'date', required: true },
+    });
+    expect(schema.properties.size).toBe(3);
+    expect(schema.required.size).toBe(1);
+
+    schema.deleteProperty('z');
+
+    expect(schema.properties.get('z')).toBeUndefined();
+    expect(schema.required.size).toBe(0);
+  });
+
+  test('clearProperties()', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'object');
+    schema.setProperties({
+      x: 'string',
+      y: 'int32',
+      z: { type: 'date', required: true },
+    });
+    schema.clearProperties();
+
+    expect(schema.properties.size).toBe(0);
+    expect(schema.required.size).toBe(0);
+  });
+
+  test('setPropertyRequired', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.createObject(openapi.components, {
+      a: 'string',
+      b: 'binary',
+      c: 'object',
+    });
+    schema.setPropertyRequired('a', true);
+    schema.setPropertyRequired('c', true);
+
+    expect(schema.required).toStrictEqual(new Set<string>(['a', 'c']));
+  });
+
+  test('addAllOf', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, null);
+    expect(schema.allOf).toBeNull();
+
+    const option1 = schema.addAllOf('integer');
+
+    const anotherSchema = SchemaFactory.create(openapi.components, null);
+    const option2 = schema.addAllOf(anotherSchema);
+
+    expect(option1).toHaveProperty('parent', schema);
+    expect(option2).toBe(anotherSchema);
+
+    expect(schema.allOf?.length).toBe(2);
+    expect(schema.allOf?.[0]).toBe(option1);
+    expect(schema.allOf?.[1]).toBe(option2);
+  });
+
+  test('deleteAllOfAt', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const schema = SchemaFactory.create(openapi.components, null);
+    schema.addAllOf('integer');
+    schema.addAllOf('double');
+
+    schema.deleteAllOfAt(0);
+
+    expect(schema.allOf).toHaveLength(1);
+    expect(schema.allOf?.[0]).toHaveProperty('type', 'number');
+
+    schema.deleteAllOfAt(0);
+
+    expect(schema.allOf).toBeNull();
+  });
+
+  test('clearAllOf', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const schema = SchemaFactory.create(openapi.components, null);
+    schema.addAllOf('integer');
+    schema.addAllOf('double');
+
+    expect(schema.allOf).toHaveLength(2);
+
+    schema.clearAllOf();
+
+    expect(schema.allOf).toBeNull();
+  });
+
+  test('arrayOf', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const itemSchema = SchemaFactory.create(openapi.components, 'integer');
+
+    const arraySchema = itemSchema.arrayOf(openapi.components);
+
+    expect(arraySchema.items).toBe(itemSchema);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -1,0 +1,252 @@
+import assert from 'assert';
+
+import { BasicNode } from './BasicNode';
+
+import type { SchemaFormat, SchemaType } from '../types';
+import type { Components } from './Components';
+import type { Discriminator } from './Discriminator';
+import type { ExternalDocumentation } from './ExternalDocumentation';
+import type { Header } from './Header';
+import type { MediaType } from './MediaType';
+import type { Parameter } from './Parameter';
+import type { HttpScheme } from './SecurityScheme/HttpScheme';
+import type {
+  SchemaCreateArrayParams,
+  SchemaCreatePropertyParams,
+  SchemaCreateType,
+  SchemaModel,
+  SchemaModelFactory,
+} from './types';
+import type { XML } from './XML';
+import type { CommonMarkString, JSONValue, Nullable } from '@fresha/api-tools-core';
+
+export type SchemaParent = Components | MediaType | Parameter | Header | Schema | HttpScheme;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#schema-object
+ */
+export class Schema extends BasicNode<SchemaParent> implements SchemaModel {
+  title: Nullable<string>;
+  multipleOf: Nullable<number>;
+  maximum: Nullable<number>;
+  exclusiveMaximum: boolean;
+  minimum: Nullable<number>;
+  exclusiveMinimum: boolean;
+  maxLength: Nullable<number>;
+  minLength: Nullable<number>;
+  pattern: Nullable<string>;
+  maxItems: Nullable<number>;
+  minItems: Nullable<number>;
+  uniqueItems: boolean;
+  maxProperties: Nullable<number>;
+  minProperties: Nullable<number>;
+  required: Set<string>;
+  enum: Nullable<JSONValue[]>;
+  type: Nullable<SchemaType>;
+  allOf: Nullable<SchemaModel[]>;
+  oneOf: Nullable<SchemaModel[]>;
+  anyOf: Nullable<SchemaModel[]>;
+  not: Nullable<SchemaModel>;
+  items: Nullable<SchemaModel>;
+  readonly properties: Map<string, SchemaModel>;
+  additionalProperties: Nullable<SchemaModel | boolean>;
+  description: Nullable<CommonMarkString>;
+  format: Nullable<SchemaFormat>;
+  default: Nullable<JSONValue>;
+  nullable: boolean;
+  discriminator: Nullable<Discriminator>;
+  readOnly: boolean;
+  writeOnly: boolean;
+  xml: Nullable<XML>;
+  externalDocs: Nullable<ExternalDocumentation>;
+  example: Nullable<JSONValue>;
+  deprecated: boolean;
+
+  static create(parent: SchemaParent, params: SchemaCreateType = null): Schema {
+    const result = new Schema(parent);
+    switch (params) {
+      case null:
+        break;
+      case 'boolean':
+      case 'object':
+      case 'array':
+      case 'integer':
+      case 'number':
+      case 'string':
+        result.type = params;
+        break;
+      case 'int32':
+      case 'int64':
+        result.type = 'integer';
+        result.format = params;
+        break;
+      case 'float':
+      case 'double':
+        result.type = 'number';
+        result.format = params;
+        break;
+      case 'byte':
+      case 'binary':
+      case 'date':
+      case 'date-time':
+      case 'password':
+        result.type = 'string';
+        result.format = params;
+        break;
+      default:
+        assert.fail(`Unsupported schema create type ${String(params)}`);
+    }
+    return result;
+  }
+
+  static createArray(
+    parent: SchemaParent,
+    params: SchemaCreateType | SchemaCreateArrayParams | Schema,
+  ): Schema {
+    const result = Schema.create(parent, 'array');
+
+    if (typeof params === 'string' || params == null) {
+      result.items = Schema.create(result, params);
+    } else if (params instanceof Schema) {
+      result.items = params;
+    } else {
+      if (typeof params.type === 'string' || params.type == null) {
+        result.items = Schema.create(result, params.type);
+      } else if (params.type instanceof Schema) {
+        result.items = params.type;
+      } else {
+        assert.fail(`Unsupported schema type ${String(params.type)}`);
+      }
+
+      if (params.minItems) {
+        result.minItems = params.minItems;
+      }
+      if (params.maxItems) {
+        result.maxItems = params.maxItems;
+      }
+    }
+    return result;
+  }
+
+  static createObject(
+    parent: SchemaParent,
+    props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>,
+  ): Schema {
+    const result = Schema.create(parent, 'object');
+    result.setProperties(props);
+    return result;
+  }
+
+  constructor(parent: SchemaParent) {
+    super(parent);
+    this.title = null;
+    this.multipleOf = null;
+    this.maximum = null;
+    this.exclusiveMaximum = false;
+    this.minimum = null;
+    this.exclusiveMinimum = false;
+    this.minLength = null;
+    this.maxLength = null;
+    this.pattern = null;
+    this.minItems = null;
+    this.maxItems = null;
+    this.uniqueItems = false;
+    this.minProperties = null;
+    this.maxProperties = null;
+    this.required = new Set<string>();
+    this.enum = null;
+    this.type = null;
+    this.allOf = null;
+    this.oneOf = null;
+    this.anyOf = null;
+    this.not = null;
+    this.items = null;
+    this.properties = new Map<string, Schema>();
+    this.additionalProperties = true;
+    this.description = null;
+    this.format = null;
+    this.default = null;
+    this.nullable = false;
+    this.discriminator = null;
+    this.readOnly = false;
+    this.writeOnly = false;
+    this.xml = null;
+    this.externalDocs = null;
+    this.example = null;
+    this.deprecated = false;
+  }
+
+  setProperty(name: string, params: SchemaCreateType | SchemaCreatePropertyParams): Schema {
+    const propertySchema = Schema.create(
+      this,
+      typeof params === 'string' || params == null ? params : params.type,
+    );
+    this.properties.set(name, propertySchema);
+    if (typeof params !== 'string' && params != null && params.required) {
+      this.required.add(name);
+    }
+    return propertySchema;
+  }
+
+  setProperties(props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>): Schema {
+    for (const [propName, propDef] of Object.entries(props)) {
+      this.setProperty(propName, propDef);
+    }
+    return this;
+  }
+
+  deleteProperty(name: string): void {
+    this.properties.delete(name);
+    this.required.delete(name);
+  }
+
+  clearProperties(): void {
+    this.properties.clear();
+    this.required.clear();
+  }
+
+  setPropertyRequired(name: string, value: boolean): void {
+    if (value) {
+      this.required.add(name);
+    } else {
+      this.required.delete(name);
+    }
+  }
+
+  addAllOf(typeOrSchema: SchemaCreateType | SchemaModel): SchemaModel {
+    if (this.allOf == null) {
+      this.allOf = [];
+    }
+    if (typeOrSchema == null || typeof typeOrSchema === 'string') {
+      const schema = Schema.create(this, typeOrSchema);
+      this.allOf.push(schema);
+      return schema;
+    }
+    this.allOf.push(typeOrSchema);
+    return typeOrSchema;
+  }
+
+  deleteAllOfAt(index: number): void {
+    if (this.allOf) {
+      this.allOf.splice(index, 1);
+      if (!this.allOf.length) {
+        this.allOf = null;
+      }
+    }
+  }
+
+  clearAllOf(): void {
+    if (this.allOf) {
+      for (const item of this.allOf) {
+        item.dispose();
+      }
+      this.allOf = null;
+    }
+  }
+
+  arrayOf(parent: SchemaParent): SchemaModel {
+    return Schema.createArray(parent, this);
+  }
+}
+
+export const SchemaFactory: SchemaModelFactory = Schema;

--- a/packages/openapi-model/src/3.0.3/model/SecurityRequirement.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityRequirement.ts
@@ -1,0 +1,22 @@
+import { BasicNode } from './BasicNode';
+
+import type { OpenAPI } from './OpenAPI';
+import type { Operation } from './Operation';
+import type { SecurityRequirementModel } from './types';
+
+export type SecurityRequirementParent = OpenAPI | Operation;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-requirement-object
+ */
+export class SecurityRequirement
+  extends BasicNode<SecurityRequirementParent>
+  implements SecurityRequirementModel
+{
+  scopes: Map<string, string[]>;
+
+  constructor(parent: SecurityRequirementParent) {
+    super(parent);
+    this.scopes = new Map<string, string[]>();
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/ApiKeyScheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/ApiKeyScheme.ts
@@ -1,0 +1,22 @@
+import { SecuritySchemeBase, SecuritySchemeParent } from './SecuritySchemeBase';
+
+import type { APIKeySecuritySchemaModel } from '../types';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export class ApiKeyScheme extends SecuritySchemeBase implements APIKeySecuritySchemaModel {
+  name: string;
+  in: 'query' | 'header' | 'cookie';
+
+  constructor(parent: SecuritySchemeParent, name: string, location: 'query' | 'header' | 'cookie') {
+    super(parent);
+    this.name = name;
+    this.in = location;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'apiKey' {
+    return 'apiKey';
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/HttpScheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/HttpScheme.ts
@@ -1,0 +1,25 @@
+import { Schema } from '../Schema';
+
+import { SecuritySchemeBase, SecuritySchemeParent } from './SecuritySchemeBase';
+
+import type { HTTPSecuritySchemaModel } from '../types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export class HttpScheme extends SecuritySchemeBase implements HTTPSecuritySchemaModel {
+  scheme: Schema;
+  bearerFormat: Nullable<string>;
+
+  constructor(parent: SecuritySchemeParent, scheme?: Schema) {
+    super(parent);
+    this.scheme = scheme ?? new Schema(this);
+    this.bearerFormat = null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'http' {
+    return 'http';
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/OAuth2Scheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/OAuth2Scheme.ts
@@ -1,0 +1,22 @@
+import { OAuthFlows } from '../OAuthFlow';
+
+import { SecuritySchemeBase, SecuritySchemeParent } from './SecuritySchemeBase';
+
+import type { OAuth2SecuritySchemaModel } from '../types';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export class OAuth2Scheme extends SecuritySchemeBase implements OAuth2SecuritySchemaModel {
+  readonly flows: OAuthFlows;
+
+  constructor(parent: SecuritySchemeParent) {
+    super(parent);
+    this.flows = new OAuthFlows(this);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'oauth2' {
+    return 'oauth2';
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectScheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectScheme.ts
@@ -1,0 +1,24 @@
+import { SecuritySchemeBase, SecuritySchemeParent } from './SecuritySchemeBase';
+
+import type { OpenIDConnectSecuritySchemaModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export class OpenIdConnectScheme
+  extends SecuritySchemeBase
+  implements OpenIDConnectSecuritySchemaModel
+{
+  openIdConnectUrl: URLString;
+
+  constructor(parent: SecuritySchemeParent, openIdConnectUrl: URLString) {
+    super(parent);
+    this.openIdConnectUrl = openIdConnectUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'openIdConnect' {
+    return 'openIdConnect';
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/SecuritySchemeBase.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/SecuritySchemeBase.ts
@@ -1,0 +1,18 @@
+import { BasicNode } from '../BasicNode';
+
+import type { Components } from '../Components';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type SecuritySchemeParent = Components;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export abstract class SecuritySchemeBase extends BasicNode<SecuritySchemeParent> {
+  description: Nullable<string>;
+
+  constructor(parent: SecuritySchemeParent) {
+    super(parent);
+    this.description = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/index.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/index.ts
@@ -1,0 +1,9 @@
+import type { ApiKeyScheme } from './ApiKeyScheme';
+import type { HttpScheme } from './HttpScheme';
+import type { OAuth2Scheme } from './OAuth2Scheme';
+import type { OpenIdConnectScheme } from './OpenIdConnectScheme';
+import type { SecuritySchemeParent } from './SecuritySchemeBase';
+
+export type SecurityScheme = ApiKeyScheme | HttpScheme | OAuth2Scheme | OpenIdConnectScheme;
+
+export type { SecuritySchemeParent };

--- a/packages/openapi-model/src/3.0.3/model/Server.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Server.test.ts
@@ -1,0 +1,44 @@
+import { OpenAPI } from './OpenAPI';
+import { Server } from './Server';
+
+let openapi: OpenAPI;
+
+beforeEach(() => {
+  openapi = new OpenAPI('Server.test', '1.2.4');
+});
+
+describe('constructor', () => {
+  test('no variables', () => {
+    const server = new Server(openapi, 'https://www.example.com');
+    expect(server.url).toBe('https://www.example.com');
+    expect(server.variables.size).toBe(0);
+  });
+
+  test('with variables', () => {
+    const server = new Server(openapi, 'https://www.{hostName}.com/{path}/{subPath}');
+    expect(server.url).toBe('https://www.{hostName}.com/{path}/{subPath}');
+    expect(server.variables.size).toBe(3);
+    expect(server.variables.get('hostName')).toBeTruthy();
+    expect(server.variables.get('path')).toBeTruthy();
+    expect(server.variables.get('subPath')).toBeTruthy();
+  });
+});
+
+test('changing server URL also updates variable map', () => {
+  const server = new Server(openapi, 'https://www.{hostName}.com/{pathName}');
+  server.variables.get('pathName')!.default = '/a/b/c';
+
+  const mockHostName = jest.fn();
+  server.variables.get('hostName')!.dispose = mockHostName;
+  const mockPathName = jest.fn();
+  server.variables.get('pathName')!.dispose = mockPathName;
+
+  server.url = 'https://www.{host}.com/{pathName}/{subPath}';
+  expect(server.variables.size).toBe(3);
+  expect(server.variables.get('host')).toBeTruthy();
+  expect(server.variables.get('pathName')).toBeTruthy();
+  expect(server.variables.get('pathName')?.default).toBe('/a/b/c');
+  expect(server.variables.get('subPath')).toBeTruthy();
+  expect(mockHostName).toHaveBeenCalled();
+  expect(mockPathName).not.toHaveBeenCalled();
+});

--- a/packages/openapi-model/src/3.0.3/model/Server.ts
+++ b/packages/openapi-model/src/3.0.3/model/Server.ts
@@ -1,0 +1,76 @@
+import { BasicNode } from './BasicNode';
+import { ServerVariable } from './ServerVariable';
+
+import type { OpenAPI } from './OpenAPI';
+import type { PathItem } from './PathItem';
+import type { ServerModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type ServerParent = OpenAPI | PathItem;
+
+const isValidVariableName = (str: string): boolean => !!str;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#server-object
+ */
+export class Server extends BasicNode<ServerParent> implements ServerModel {
+  private mUrl: string;
+  description: Nullable<string>;
+  private readonly mVariables: Map<string, ServerVariable>;
+
+  constructor(parent: ServerParent, url: string, variableDefaults?: Record<string, string>) {
+    super(parent);
+    this.mUrl = url;
+    this.description = null;
+    this.mVariables = new Map<string, ServerVariable>();
+    this.syncVariables(url);
+    if (variableDefaults) {
+      for (const [name, variable] of this.mVariables) {
+        if (variableDefaults[name] != null) {
+          variable.default = variableDefaults[name];
+        }
+      }
+    }
+  }
+
+  get url(): string {
+    return this.mUrl;
+  }
+
+  set url(newUrl: string) {
+    if (newUrl !== this.mUrl) {
+      this.mUrl = newUrl;
+      this.syncVariables(newUrl);
+    }
+  }
+
+  get variables(): ReadonlyMap<string, ServerVariable> {
+    return this.mVariables;
+  }
+
+  setVariableDefault(name: string, value: string): void {
+    const variable = this.mVariables.get(name);
+    if (!variable) {
+      throw new Error(`Unknown variable ${name}`);
+    }
+    variable.default = value;
+  }
+
+  private syncVariables(newUrl: string): void {
+    const newVarNames = (newUrl.match(/\{.+?\}/g) || []).map(elem => elem.slice(1, -1));
+    if (!newVarNames.every(isValidVariableName)) {
+      throw new Error(`Illegal variable name in server URL "${newUrl}"`);
+    }
+    for (const [name, variable] of this.mVariables) {
+      if (!newVarNames.includes(name)) {
+        variable.dispose();
+        this.mVariables.delete(name);
+      }
+    }
+    for (const newName of newVarNames) {
+      if (!this.mVariables.has(newName)) {
+        this.mVariables.set(newName, new ServerVariable(this, ''));
+      }
+    }
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/ServerVariable.ts
+++ b/packages/openapi-model/src/3.0.3/model/ServerVariable.ts
@@ -1,0 +1,23 @@
+import { BasicNode } from './BasicNode';
+
+import type { Server } from './Server';
+import type { ServerVariableModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type ServerVariableParent = Server;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#server-variable-object
+ */
+export class ServerVariable extends BasicNode<ServerVariableParent> implements ServerVariableModel {
+  enum: Nullable<string[]>;
+  default: string;
+  description: Nullable<string>;
+
+  constructor(parent: ServerVariableParent, defaultValue: string) {
+    super(parent);
+    this.enum = null;
+    this.default = defaultValue;
+    this.description = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/Tag.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Tag.test.ts
@@ -1,0 +1,13 @@
+import { OpenAPI } from './OpenAPI';
+import { Tag } from './Tag';
+
+let parent: OpenAPI;
+
+beforeEach(() => {
+  parent = new OpenAPI('Tag.test', '0.0.1');
+});
+
+test('constructor', () => {
+  const tag = new Tag(parent, 'tag#1');
+  expect(tag.name).toBe('tag#1');
+});

--- a/packages/openapi-model/src/3.0.3/model/Tag.ts
+++ b/packages/openapi-model/src/3.0.3/model/Tag.ts
@@ -1,0 +1,25 @@
+import { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+import { BasicNode } from './BasicNode';
+
+import type { ExternalDocumentation } from './ExternalDocumentation';
+import type { OpenAPI } from './OpenAPI';
+import type { TagModel } from './types';
+
+export type TagParent = OpenAPI;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#tag-object
+ */
+export class Tag extends BasicNode<TagParent> implements TagModel {
+  name: string;
+  description: Nullable<CommonMarkString>;
+  externalDocs: Nullable<ExternalDocumentation>;
+
+  constructor(parent: TagParent, name: string) {
+    super(parent);
+    this.name = name;
+    this.description = null;
+    this.externalDocs = null;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/XML.ts
+++ b/packages/openapi-model/src/3.0.3/model/XML.ts
@@ -1,0 +1,27 @@
+import { BasicNode } from './BasicNode';
+
+import type { Schema } from './Schema';
+import type { XMLModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export type XMLParent = Schema;
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#xml-object
+ */
+export class XML extends BasicNode<XMLParent> implements XMLModel {
+  name: Nullable<string>;
+  namespace: Nullable<string>;
+  prefix: Nullable<string>;
+  attribute: boolean;
+  wrapped: boolean;
+
+  constructor(parent: XMLParent) {
+    super(parent);
+    this.name = null;
+    this.namespace = null;
+    this.prefix = null;
+    this.attribute = false;
+    this.wrapped = false;
+  }
+}

--- a/packages/openapi-model/src/3.0.3/model/index.ts
+++ b/packages/openapi-model/src/3.0.3/model/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export { OpenAPIReader } from './OpenAPIReader';
+export { OpenAPIWriter } from './OpenAPIWriter';

--- a/packages/openapi-model/src/3.0.3/model/types.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.test.ts
@@ -1,0 +1,220 @@
+import fs from 'fs';
+import path from 'path';
+
+import yaml from 'yaml';
+
+import { OpenAPI } from './OpenAPI';
+import { OpenAPIWriter } from './OpenAPIWriter';
+import { Operation } from './Operation';
+import { RequestBody } from './RequestBody';
+import { Schema, SchemaFactory } from './Schema';
+
+import type { MediaType } from './MediaType';
+import type { PathParameter, QueryParameter } from './Parameter';
+import type { OpenAPIModel } from './types';
+import type { JSONObject } from '@fresha/api-tools-core';
+
+test('how easy is to use this class', () => {
+  const api: OpenAPIModel = new OpenAPI('Test of this class ease of use', '0.1.0');
+
+  api.info.contact.name = 'developers';
+  api.info.contact.url = 'https://www.examples.com';
+
+  api.addServer('http://localhost:{port}', { port: '4700' }, 'local');
+  api.addServer('https://partners-api-{namespace}.{domain}', {
+    namespace: 'staging',
+    domain: 'dev.fresha.io',
+  });
+  api.addServer('https://partners-app.fresha.com');
+
+  const pathItem = api.setPathItem('/api/v1');
+  const operation = pathItem.addOperation('get');
+
+  expect(pathItem.get).toBe(operation);
+});
+
+test('build schema - simple', () => {
+  const api: OpenAPIModel = new OpenAPI('Sample API', '1.0.0');
+  api.info.description = 'A sample API to illustrate OpenAPI concepts';
+
+  const pathItem = api.setPathItem('/list');
+  const operation = pathItem.addOperation('get');
+  operation.description = 'Returns a list of stuff';
+  operation.responses.setResponse(200, 'Successful response');
+
+  const writer = new OpenAPIWriter();
+  const outputData = writer.write(api as OpenAPI);
+
+  const inputText = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'examples', 'simple.yaml'),
+    'utf-8',
+  );
+  const inputData = yaml.parse(inputText) as JSONObject;
+
+  expect(outputData).toStrictEqual(inputData);
+});
+
+test('build schema - petstore', () => {
+  const api = new OpenAPI('Swagger Petstore', '1.0.0');
+
+  // info
+  api.info.description =
+    'A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification';
+  api.info.termsOfService = 'http://swagger.io/terms/';
+  api.info.contact.name = 'Swagger API Team';
+  api.info.contact.email = 'apiteam@swagger.io';
+  api.info.contact.url = 'http://swagger.io';
+  api.info.license.name = 'Apache 2.0';
+  api.info.license.url = 'https://www.apache.org/licenses/LICENSE-2.0.html';
+
+  // servers
+  api.addServer('http://petstore.swagger.io/api');
+
+  //
+  // components
+  //
+
+  const newPetSchema = api.components.setSchema('NewPet', 'object').setProperties({
+    name: { type: 'string', required: true },
+    tag: 'string',
+  });
+
+  const errorSchema = api.components.setSchema('Error', 'object').setProperties({
+    code: { type: 'int32', required: true },
+    message: { type: 'string', required: true },
+  });
+
+  const petSchema = api.components.setSchema('Pet');
+  petSchema.addAllOf(newPetSchema);
+
+  const idSchema = petSchema.addAllOf('object');
+  idSchema.setProperty('id', { type: 'int64', required: true });
+
+  //
+  // pathItems
+  //
+
+  const collectionPathItem = api.setPathItem('/pets');
+
+  //
+  // findPets
+  //
+
+  const findPetsOperation = collectionPathItem.addOperation('get');
+  findPetsOperation.description = `Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+`;
+  findPetsOperation.operationId = 'findPets';
+
+  const paramTags = findPetsOperation.addParameter('tags', 'query') as QueryParameter;
+  paramTags.description = 'tags to filter by';
+  paramTags.schema = Schema.createArray(paramTags, 'string');
+
+  const paramLimit = findPetsOperation.addParameter('limit', 'query') as QueryParameter;
+  paramLimit.description = 'maximum number of results to return';
+  paramLimit.schema = SchemaFactory.create(paramLimit, 'int32') as Schema;
+
+  const findPetsResponse200 = findPetsOperation.responses.setResponse(200, 'pet response');
+  const findPetsMediaType200 = findPetsResponse200.setContent('application/json') as MediaType;
+  findPetsMediaType200.schema = petSchema.arrayOf(findPetsMediaType200) as Schema;
+
+  const findPetsDefaultResponse =
+    findPetsOperation.responses.setDefaultResponse('unexpected error');
+  const findPetsDefaultMediaType = findPetsDefaultResponse.setContent(
+    'application/json',
+  ) as MediaType;
+  findPetsDefaultMediaType.schema = errorSchema as Schema;
+
+  //
+  // addPet
+  //
+
+  const addPetOperation = collectionPathItem.addOperation('post');
+  addPetOperation.description = 'Creates a new pet in the store. Duplicates are allowed';
+  addPetOperation.operationId = 'addPet';
+
+  const addPetRequest = new RequestBody(addPetOperation as Operation);
+  addPetRequest.description = 'Pet to add to the store';
+  addPetRequest.required = true;
+  addPetOperation.requestBody = addPetRequest;
+
+  const addPetMediaType = addPetRequest.setContent('application/json');
+  addPetMediaType.schema = newPetSchema as Schema;
+
+  const addPetResponse200 = addPetOperation.responses.setResponse(200, 'pet response');
+  const mediaType200 = addPetResponse200.setContent('application/json') as MediaType;
+  mediaType200.schema = petSchema as Schema;
+
+  const addPetDefaultResponse = addPetOperation.responses.setDefaultResponse('unexpected error');
+  const addPetDefaultResponseMediaType = addPetDefaultResponse.setContent(
+    'application/json',
+  ) as MediaType;
+  addPetDefaultResponseMediaType.schema = errorSchema as Schema;
+
+  const itemPathItem = api.setPathItem('/pets/{id}');
+
+  //
+  // find pet by id
+  //
+
+  const getPetOperation = itemPathItem.addOperation('get');
+  getPetOperation.description =
+    'Returns a user based on a single ID, if the user does not have access to the pet';
+  getPetOperation.operationId = 'find pet by id';
+
+  const getIdParam = getPetOperation.addParameter('id', 'path') as PathParameter;
+  getIdParam.description = 'ID of pet to fetch';
+  getIdParam.schema = SchemaFactory.create(getIdParam, 'int64') as Schema;
+
+  const getPetResponse200 = getPetOperation.responses.setResponse(200, 'pet response');
+  const getPetMediaType200 = getPetResponse200.setContent('application/json') as MediaType;
+  getPetMediaType200.schema = petSchema as Schema;
+
+  const getPetDefaultResponse = getPetOperation.responses.setDefaultResponse('unexpected error');
+  const getPetDefaultMediaType = getPetDefaultResponse.setContent('application/json') as MediaType;
+  getPetDefaultMediaType.schema = errorSchema as Schema;
+
+  //
+  // deletePet
+  //
+
+  const deletePetOperation = itemPathItem.addOperation('delete');
+  deletePetOperation.description = 'deletes a single pet based on the ID supplied';
+  deletePetOperation.operationId = 'deletePet';
+
+  const deleteIdParam = deletePetOperation.addParameter('id', 'path') as PathParameter;
+  deleteIdParam.description = 'ID of pet to delete';
+  deleteIdParam.schema = Schema.create(deleteIdParam, 'int64');
+
+  // const deleteResponse204 = deletePetOperation.responses.setResponse(204, 'pet deleted');
+  deletePetOperation.responses.setResponse(204, 'pet deleted');
+  // deleteResponse204.setContent('application/json');
+
+  const deleteResponseDefault = deletePetOperation.responses.setDefaultResponse('unexpected error');
+  const deleteResponseMediaType = deleteResponseDefault.setContent('application/json') as MediaType;
+  deleteResponseMediaType.schema = errorSchema as Schema;
+
+  //
+  // tags
+  //
+
+  api.addTag('tag1').description = 'The first tag';
+  api.addTag('tag2').description = 'Second tag';
+
+  //
+  // comparison
+  //
+
+  const writer = new OpenAPIWriter();
+  const outputData = writer.write(api);
+
+  const inputText = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'examples', 'petstore.yaml'),
+    'utf-8',
+  );
+  const inputData = yaml.parse(inputText) as JSONObject;
+
+  expect(outputData).toStrictEqual(inputData);
+});

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -1,0 +1,622 @@
+import { SchemaParent } from './Schema';
+
+import type {
+  PathParameterSerializationStyle,
+  QueryParameterSerializationStyle,
+  Ref,
+  SchemaFormat,
+  SchemaType,
+} from '../types';
+import type {
+  CommonMarkString,
+  EmailString,
+  JSONValue,
+  Nullable,
+  URLString,
+  VersionString,
+} from '@fresha/api-tools-core';
+
+export { PathParameterSerializationStyle, QueryParameterSerializationStyle, Ref };
+
+export type OpenApiVersion = '3.0.3';
+export type ParametrisedURLString = string; // URLString with interpolations, like /list/{from}/{to}
+
+export type MIMETypeString = string;
+
+export interface Disposable {
+  dispose(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#specification-extensions
+ */
+export interface SpecificationExtensionsModel {
+  readonly extensions: ReadonlyMap<string, JSONValue>;
+
+  setExtension(key: string, value: JSONValue): void;
+  deleteExtension(key: string): void;
+  clearExtensions(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#discriminator-object
+ */
+export interface DiscriminatorModel extends Disposable, SpecificationExtensionsModel {
+  propertyName: string;
+  readonly mapping: ReadonlyMap<string, string>;
+}
+
+export type SchemaCreateType = null | SchemaType | SchemaFormat;
+
+export type SchemaCreatePropertyParams = {
+  type: SchemaCreateType;
+  required?: boolean;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#schema-object
+ */
+export interface SchemaModel extends Disposable, SpecificationExtensionsModel {
+  title: Nullable<string>;
+  multipleOf: Nullable<number>;
+  maximum: Nullable<number>;
+  exclusiveMaximum: boolean;
+  minimum: Nullable<number>;
+  exclusiveMinimum: boolean;
+  maxLength: Nullable<number>;
+  minLength: Nullable<number>;
+  pattern: Nullable<string>;
+  maxItems: Nullable<number>;
+  minItems: Nullable<number>;
+  uniqueItems: boolean;
+  maxProperties: Nullable<number>;
+  minProperties: Nullable<number>;
+  readonly required: Set<string>;
+  enum: Nullable<JSONValue[]>;
+  type: Nullable<SchemaType>;
+  allOf: Nullable<SchemaModel[]>;
+  oneOf: Nullable<SchemaModel[]>;
+  anyOf: Nullable<SchemaModel[]>;
+  not: Nullable<SchemaModel>;
+  items: Nullable<SchemaModel>;
+  readonly properties: ReadonlyMap<string, SchemaModel>;
+  additionalProperties: Nullable<SchemaModel | boolean>;
+  description: Nullable<CommonMarkString>;
+  format: Nullable<SchemaFormat>;
+  default: Nullable<JSONValue>;
+  nullable: boolean;
+  discriminator: Nullable<DiscriminatorModel>;
+  readOnly: boolean;
+  writeOnly: boolean;
+  xml: Nullable<XMLModel>;
+  externalDocs: Nullable<ExternalDocumentationModel>;
+  example: Nullable<JSONValue>;
+  deprecated: boolean;
+
+  setProperty(name: string, type: SchemaCreateType | SchemaCreatePropertyParams): SchemaModel;
+  setProperties(props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>): SchemaModel;
+  deleteProperty(name: string): void;
+  clearProperties(): void;
+
+  setPropertyRequired(name: string, value: boolean): void;
+
+  addAllOf(typeOrSchema: SchemaCreateType | SchemaModel): SchemaModel;
+  deleteAllOfAt(index: number): void;
+  clearAllOf(): void;
+
+  arrayOf(parent: SchemaParent): SchemaModel;
+}
+
+export type SchemaCreateArrayParams = {
+  type: SchemaCreateType | SchemaModel;
+  minItems?: number;
+  maxItems?: number;
+};
+
+/**
+ * This class provides convenience methods for creating SchemaObject-s.
+ */
+export interface SchemaModelFactory {
+  create(parent: SchemaParent, params: SchemaCreateType): SchemaModel;
+  createArray(
+    parent: SchemaParent,
+    params: SchemaCreateType | SchemaCreateArrayParams | SchemaModel,
+  ): SchemaModel;
+  createObject(
+    parent: SchemaParent,
+    props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>,
+  ): SchemaModel;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#contact-object
+ */
+export interface ContactModel extends Disposable, SpecificationExtensionsModel {
+  name: Nullable<string>;
+  url: Nullable<string>;
+  email: Nullable<EmailString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#license-object
+ */
+export interface LicenseModel extends Disposable, SpecificationExtensionsModel {
+  name: string;
+  url: Nullable<URLString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#info-object
+ */
+export interface InfoModel extends Disposable, SpecificationExtensionsModel {
+  title: string;
+  description: Nullable<CommonMarkString>;
+  termsOfService: Nullable<URLString>;
+  readonly contact: ContactModel;
+  readonly license: LicenseModel;
+  version: VersionString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#server-variable-object
+ */
+export interface ServerVariableModel extends Disposable, SpecificationExtensionsModel {
+  enum: Nullable<string[]>;
+  default: string;
+  description: Nullable<CommonMarkString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#server-object
+ */
+export interface ServerModel extends Disposable, SpecificationExtensionsModel {
+  url: string;
+  description: Nullable<CommonMarkString>;
+  readonly variables: ReadonlyMap<string, ServerVariableModel>;
+
+  setVariableDefault(name: string, value: string): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#external-documentation-object
+ */
+export interface ExternalDocumentationModel extends Disposable, SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+  url: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export interface ParameterBaseModel extends Disposable, SpecificationExtensionsModel {
+  name: string;
+  description: Nullable<CommonMarkString>;
+  deprecated: boolean;
+  schema: Nullable<SchemaModel>;
+  example: Nullable<JSONValue>;
+  readonly examples: ReadonlyMap<string, ExampleModel>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export interface PathParameterModel extends Disposable, ParameterBaseModel {
+  readonly in: 'path';
+  readonly required: true;
+  style: PathParameterSerializationStyle;
+  explode: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export interface QueryParameterModel extends Disposable, ParameterBaseModel {
+  readonly in: 'query';
+  required: boolean;
+  allowEmptyValue: boolean;
+  style: QueryParameterSerializationStyle;
+  explode: boolean;
+  allowReserved: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export interface HeaderParameterModel extends Disposable, ParameterBaseModel {
+  readonly in: 'header';
+  required: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export interface CookieParameterModel extends Disposable, ParameterBaseModel {
+  readonly in: 'cookie';
+  required: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type ParameterModel =
+  | PathParameterModel
+  | QueryParameterModel
+  | HeaderParameterModel
+  | CookieParameterModel;
+
+export type ParameterLocation = ParameterModel['in'];
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#example-object
+ */
+export interface ExampleModel extends Disposable, SpecificationExtensionsModel {
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  value: JSONValue;
+  externalValue: Nullable<string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#header-object
+ */
+export interface HeaderModel extends Disposable, SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+  required: boolean;
+  deprecated: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#encoding-object
+ */
+export interface EncodingModel extends Disposable, SpecificationExtensionsModel {
+  contentType: Nullable<string>;
+  readonly headers: ReadonlyMap<string, HeaderModel>;
+  style: Nullable<string>;
+  explode: boolean;
+  allowReserved: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#media-type-object
+ */
+export interface MediaTypeModel extends Disposable, SpecificationExtensionsModel {
+  schema: Nullable<SchemaModel>;
+  example: JSONValue;
+  readonly examples: ReadonlyMap<string, ExampleModel>;
+  readonly encoding: ReadonlyMap<string, EncodingModel>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#request-body-object
+ */
+export interface RequestBodyModel extends Disposable, SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+  readonly content: ReadonlyMap<MIMETypeString, MediaTypeModel>;
+  required: boolean;
+
+  setContent(mimeType: MIMETypeString): MediaTypeModel;
+  deleteContent(mimeType: MIMETypeString): void;
+  clearContent(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#response-object
+ */
+export interface ResponseModel extends Disposable, SpecificationExtensionsModel {
+  description: CommonMarkString;
+  readonly headers: ReadonlyMap<string, HeaderModel>; // key = HTTP header name
+  readonly content: ReadonlyMap<MIMETypeString, MediaTypeModel>; // key = MIME media type
+  readonly links: ReadonlyMap<string, LinkModel>; // key = short name of the link
+
+  setContent(mimeType: MIMETypeString): MediaTypeModel;
+  deleteContent(mimeType: MIMETypeString): void;
+  clearContent(): void;
+}
+
+export type HTTPStatusCode = number | string;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#responses-object
+ */
+export interface ResponsesModel extends Disposable, SpecificationExtensionsModel {
+  default: Nullable<ResponseModel>;
+  readonly codes: ReadonlyMap<HTTPStatusCode, ResponseModel>;
+
+  setDefaultResponse(description: CommonMarkString): ResponseModel;
+  deleteDefaultResponse(): void;
+
+  setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel;
+  deleteResponse(code: HTTPStatusCode): void;
+  clearResponses(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#operation-object
+ */
+export interface OperationModel extends Disposable, SpecificationExtensionsModel {
+  readonly tags: ReadonlyArray<string>;
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  externalDocs: Nullable<ExternalDocumentationModel>;
+  operationId: Nullable<string>;
+  requestBody: Nullable<RequestBodyModel>;
+  readonly responses: ResponsesModel;
+  callbacks: Nullable<Map<string, CallbackModel>>;
+  deprecated: boolean;
+  security: Nullable<SecurityRequirementModel[]>;
+  servers: Nullable<ServerModel[]>;
+  readonly parameters: ParameterModel[];
+
+  addParameter(name: string, source: 'path'): PathParameterModel;
+  addParameter(name: string, source: 'query'): QueryParameterModel;
+  addParameter(name: string, source: 'header'): HeaderParameterModel;
+  addParameter(name: string, source: 'cookie'): CookieParameterModel;
+  deleteParameter(name: string): void;
+  clearParameters(): void;
+
+  addTag(name: string): void;
+  deleteTag(name: string): void;
+  deleteTagAt(index: number): void;
+  clearTags(): void;
+}
+
+export type HTTPMethod = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#paths-object
+ */
+export interface PathItemModel extends Disposable, SpecificationExtensionsModel {
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  get: Nullable<OperationModel>;
+  put: Nullable<OperationModel>;
+  post: Nullable<OperationModel>;
+  delete: Nullable<OperationModel>;
+  options: Nullable<OperationModel>;
+  head: Nullable<OperationModel>;
+  patch: Nullable<OperationModel>;
+  trace: Nullable<OperationModel>;
+  servers: Nullable<ServerModel[]>;
+  // parameters: Nullable<IParameter[]>;
+
+  operations(): IterableIterator<[HTTPMethod, OperationModel]>;
+
+  addOperation(method: HTTPMethod): OperationModel;
+  removeOperation(method: HTTPMethod): void;
+  clearOperations(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#paths-object
+ */
+export interface PathsModel
+  extends Disposable,
+    Map<ParametrisedURLString, PathItemModel>,
+    SpecificationExtensionsModel {}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface SecuritySchemaBaseModel extends Disposable, SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface APIKeySecuritySchemaModel extends Disposable, SecuritySchemaBaseModel {
+  readonly type: 'apiKey';
+  name: string;
+  in: 'query' | 'header' | 'cookie';
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface HTTPSecuritySchemaModel extends Disposable, SecuritySchemaBaseModel {
+  readonly type: 'http';
+  description: Nullable<CommonMarkString>;
+  scheme: SchemaModel;
+  bearerFormat: Nullable<string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+interface OAuthFlowBaseModel extends Disposable, SpecificationExtensionsModel {
+  refreshUrl: Nullable<URLString>;
+  readonly scopes: ReadonlyMap<string, string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export interface OAuthImplicitFlowModel extends Disposable, OAuthFlowBaseModel {
+  authorizationUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export interface OAuthPasswordFlowModel extends Disposable, OAuthFlowBaseModel {
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export interface OAuthClientCredentialsFlowModel extends Disposable, OAuthFlowBaseModel {
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ */
+export interface OAuthAuthorizationCodeFlowModel extends Disposable, OAuthFlowBaseModel {
+  authorizationUrl: URLString;
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flows-object
+ */
+export interface OAuthFlowsModel extends Disposable, SpecificationExtensionsModel {
+  implicit: Nullable<OAuthImplicitFlowModel>;
+  password: Nullable<OAuthPasswordFlowModel>;
+  clientCredentials: Nullable<OAuthClientCredentialsFlowModel>;
+  authorizationCode: Nullable<OAuthAuthorizationCodeFlowModel>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface OAuth2SecuritySchemaModel extends Disposable, SecuritySchemaBaseModel {
+  readonly type: 'oauth2';
+  readonly flows: OAuthFlowsModel;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export interface OpenIDConnectSecuritySchemaModel extends Disposable, SecuritySchemaBaseModel {
+  readonly type: 'openIdConnect';
+  openIdConnectUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export type SecuritySchemaModel =
+  | APIKeySecuritySchemaModel
+  | HTTPSecuritySchemaModel
+  | OAuth2SecuritySchemaModel
+  | OpenIDConnectSecuritySchemaModel;
+
+export type SecuritySchemeType = SecuritySchemaModel['type'];
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#link-object
+ */
+export interface LinkModel extends Disposable, SpecificationExtensionsModel {
+  operationRef: Nullable<string>;
+  operationId: Nullable<string>;
+  readonly parameters: ReadonlyMap<string, JSONValue>;
+  requestBody: JSONValue;
+  description: Nullable<CommonMarkString>;
+  server: Nullable<ServerModel>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#callback-object
+ */
+export interface CallbackModel extends Disposable, SpecificationExtensionsModel {
+  readonly paths: ReadonlyMap<ParametrisedURLString, PathItemModel>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#components-object
+ */
+export interface ComponentsModel extends Disposable, SpecificationExtensionsModel {
+  readonly schemas: ReadonlyMap<string, SchemaModel>;
+  readonly responses: ReadonlyMap<string, ResponseModel>;
+  readonly parameters: ReadonlyMap<string, ParameterModel>;
+  readonly examples: ReadonlyMap<string, ExampleModel>;
+  readonly requestBodies: ReadonlyMap<string, RequestBodyModel>;
+  readonly headers: ReadonlyMap<string, HeaderModel>;
+  readonly securitySchemas: ReadonlyMap<string, SecuritySchemaModel>;
+  readonly links: ReadonlyMap<string, LinkModel>;
+  readonly callbacks: ReadonlyMap<string, CallbackModel>;
+
+  setSchema(name: string, type?: SchemaType): SchemaModel;
+  deleteSchema(name: string): void;
+  clearSchemas(): void;
+
+  setResponse(name: string, description: CommonMarkString): ResponseModel;
+  deleteResponse(name: string): void;
+  clearResponses(): void;
+
+  setParameter(name: string, kind: ParameterModel['in'], paramName: string): ParameterModel;
+  deleteParameter(name: string): void;
+  clearParameters(): void;
+
+  setExample(name: string): ExampleModel;
+  deleteExample(name: string): void;
+  clearExamples(): void;
+
+  setRequestBody(name: string): RequestBodyModel;
+  deleteRequestBody(name: string): void;
+  clearRequestBodies(): void;
+
+  setHeader(name: string): HeaderModel;
+  deleteHeader(name: string): void;
+  clearHeaders(): void;
+
+  setSecuritySchema(name: string, kind: SecuritySchemaModel['type']): SecuritySchemaModel;
+  deleteSecuritySchema(name: string): void;
+  clearSecuritySchemas(): void;
+
+  setLink(name: string): LinkModel;
+  deleteLink(name: string): void;
+  clearLinks(): void;
+
+  setCallback(name: string): CallbackModel;
+  deleteCallback(name: string): void;
+  clearCallbacks(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-requirement-object
+ */
+export interface SecurityRequirementModel extends Disposable, SpecificationExtensionsModel {
+  readonly scopes: ReadonlyMap<string, string[]>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#tag-object
+ */
+export interface TagModel extends Disposable, SpecificationExtensionsModel {
+  name: string;
+  description: Nullable<CommonMarkString>;
+  externalDocs: Nullable<ExternalDocumentationModel>;
+}
+
+/**
+ * @see http://spec.openapis.org/oas/v3.0.3#xml-object
+ */
+export interface XMLModel extends Disposable, SpecificationExtensionsModel {
+  name: Nullable<string>;
+  namespace: Nullable<string>;
+  prefix: Nullable<string>;
+  attribute: boolean;
+  wrapped: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#version-3.0.3
+ */
+export interface OpenAPIModel extends Disposable, SpecificationExtensionsModel {
+  readonly openapi: OpenApiVersion;
+  readonly info: InfoModel;
+  readonly servers: ReadonlyArray<ServerModel>; // by default it contains a server with '/' url
+  readonly paths: PathsModel;
+  readonly components: ComponentsModel;
+  readonly tags: ReadonlyArray<TagModel>;
+  readonly externalDocs: Nullable<ExternalDocumentationModel>;
+
+  addServer(
+    url: ParametrisedURLString,
+    variableDefaults?: Record<string, string>,
+    description?: CommonMarkString,
+  ): ServerModel;
+  removeServerAt(index: number): void;
+  clearServers(): void;
+
+  setPathItem(url: ParametrisedURLString): PathItemModel;
+  deletePathItem(url: ParametrisedURLString): void;
+  clearPathItems(): void;
+
+  addTag(name: string): TagModel;
+  deleteTag(name: string): void;
+  deleteTagAt(index: number): void;
+  clearTags(): void;
+}

--- a/packages/openapi-model/src/3.0.3/types.ts
+++ b/packages/openapi-model/src/3.0.3/types.ts
@@ -33,12 +33,14 @@ export type {
   APIKeySecuritySchemeObject,
   ContactObject,
   CookieParameterSerializationStyle,
+  DiscriminatorObject,
   ExampleObject,
   ExternalDocumentationObject,
   InfoObject,
   LicenseObject,
   LinkObject,
   OAuth2SecuritySchemeObject,
+  ObjectOrRef,
   OpenIdConnectSecuritySchemeObject,
   PathParameterSerializationStyle,
   QueryParameterSerializationStyle,
@@ -47,6 +49,7 @@ export type {
   ServerObject,
   ServerVariableObject,
   TagObject,
+  XMLObject,
 } from '../baseTypes';
 
 /**
@@ -153,13 +156,13 @@ export type SchemaObject = {
   required?: string[];
   enum?: JSONValue[];
   type?: SchemaType;
-  allOf?: SchemaObject[];
-  oneOf?: SchemaObject[];
-  anyOf?: SchemaObject[];
-  not?: SchemaObject;
-  items?: SchemaObject;
-  properties?: Record<string, SchemaObject>;
-  additionalProperties?: SchemaObject | boolean;
+  allOf?: ObjectOrRef<SchemaObject>[];
+  oneOf?: ObjectOrRef<SchemaObject>[];
+  anyOf?: ObjectOrRef<SchemaObject>[];
+  not?: ObjectOrRef<SchemaObject>;
+  items?: ObjectOrRef<SchemaObject>;
+  properties?: Record<string, ObjectOrRef<SchemaObject>>;
+  additionalProperties?: ObjectOrRef<SchemaObject> | boolean;
   description?: CommonMarkString;
   format?: SchemaFormat;
   default?: JSONValue;


### PR DESCRIPTION
## Overview

This PR implements an object-oriented abstraction over OpenAPI v3.0.3 schema.
Models implementations are minimalistic, just enough to be used in code generators.

## Design Notes

Currently, we use v.3.0.3 of OpenAPI specification. Support for v3.1.0 will be implemented later.

### Some important files

- `src/baseTypes.ts` - raw schema objects, parametrised by `SchemaObject` type
- `src/v3.0.3/types.ts` - typings of raw schema objects for OpenAPI v3.0.3. Whenever possible, they use types defined in `baseTypes.ts`
- `src/v3.0.3/model/types.ts` - definitions of model APIs. **This is the public interface of this library**.
- `src/v3.0.3/model/*.ts` - model implementations. Users shouldn't use these classes directly.
- `src/v3.1.0/types.ts` - same as previous, but for v.3.10

### How models' API is designed

- each entity from OpenAPI specification is represented by 2 definitions:
    - raw JSON object, how it is stored in files. These are named in the same way as in the specification, e.g. `ResponseObject`
    - model, which represents a high-level abstraction over the entity. Names of these models ends with `Model`, e.g. `RequestBodyModel`
- model classes are composed in tree, with root being the `OpenAPIModel` object. General idea is to make the tree to be in valid state (e.g. no dangling references) all the time
- model classes' API is hybrid. For querying they provide attributes. For mutations, one should use methods. For example:

```typescript
// represents the Components Object from OpenAPI spec
export interface ComponentsModel {
  // query interface - uses ReadonlyMap
  // if the attribute is a collection itself, it shouldn't be null. It also should be readonly
  readonly schemas: ReadonlyMap<string, SchemaModel>;

  // mutation API for key-value collection

  // setXXX takes at least 1 arguments, which is the key.
  // semantic of this method is similar to that of setAttribute method in DOM
  // i.e. if there's no schema under given key, it creates one and assigns it to given key
  // if there's existing schema, it's replaced
  setSchema(key: string, type: SchemaCreateType): SchemaModel;

  // deletes schema associated with given key
  deleteSchema(key: string): void;

  // deletes all schemas from the collection
  clearSchemas(): void;
}
```

- for key-value containers use `Map`. Do not use `Record`
- functions that mutate key-value containers should be named like `setXXX(key: TKey, value: TValue)`, `deleteXXX(key: TKey)` and `clearXXXs()`
- model properties that are key-value containers should use `Map` and should be declared as `ReadonlyMap` in interfaces

- for index-based collections, use `ReadonlyArray<T>` in typings
- functions that mutate index-based collections should be named like `addXXX(props)`, `insertXXXAt(index, props)`,  `deleteXXXAt(index)` and `clearXXXs()`. For example:

```typescript
class OpenAPIModel {
  readonly tags: ReadonlyArray<TagModel>;

  // as the sole argument one should pass whatever necessary to create a new TagModel object
  // parent-children relationships are handled by this method. Aha, this method appends newly
  // created TagModel to the list of existing tags
  addTag(name: string): TagModel;

  // same as previous, but instead of appending tag model to the list, it inserts it at given position
  insertTagAt(index: number, name: string): TagModel;

  // deletes tag model at given index
  deleteTagAt(index: number): void;

  // deletes all tags from the collection
  clearTags(): void;
}
```

- serialisation / deserialisation is performed by dedicated classes, `OpenAPIReader` and `OpenAPIWriter`

### Limitations

- no notifications on model changes (to be done later)
- API of rarely used  models is not complete (to be done later)
- test coverage is not yet sufficient