### PR TITLE
Add clean, prebuild and prebuild:watch common NPM scripts

### DIFF
--- a/packages/api-tools-core/package.json
+++ b/packages/api-tools-core/package.json
@@ -9,10 +9,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-codegen-client-typescript/package.json
+++ b/packages/asyncapi-codegen-client-typescript/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-codegen-server-elixir/package.json
+++ b/packages/asyncapi-codegen-server-elixir/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-codegen-server-nestjs/package.json
+++ b/packages/asyncapi-codegen-server-nestjs/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-codegen/package.json
+++ b/packages/asyncapi-codegen/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-diff/package.json
+++ b/packages/asyncapi-diff/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-lint/package.json
+++ b/packages/asyncapi-lint/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-model/package.json
+++ b/packages/asyncapi-model/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/asyncapi-validator/package.json
+++ b/packages/asyncapi-validator/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/designer-app/package.json
+++ b/packages/designer-app/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/designer-devtools/package.json
+++ b/packages/designer-devtools/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/designer-web/package.json
+++ b/packages/designer-web/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/har-extract/package.json
+++ b/packages/har-extract/package.json
@@ -11,10 +11,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/json-api-codegen/package.json
+++ b/packages/json-api-codegen/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/json-api-model/package.json
+++ b/packages/json-api-model/package.json
@@ -9,10 +9,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/json-schema-codegen/package.json
+++ b/packages/json-schema-codegen/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/json-schema-model/package.json
+++ b/packages/json-schema-model/package.json
@@ -9,10 +9,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-codegen-client-typescript/package.json
+++ b/packages/openapi-codegen-client-typescript/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-codegen-server-elixir/package.json
+++ b/packages/openapi-codegen-server-elixir/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-codegen-server-nestjs/package.json
+++ b/packages/openapi-codegen-server-nestjs/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-codegen/package.json
+++ b/packages/openapi-codegen/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-diff/package.json
+++ b/packages/openapi-diff/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-lint/package.json
+++ b/packages/openapi-lint/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -8,11 +8,14 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
-    "_lint": "run-s eslint typecheck",
-    "_lint:fix": "run-s eslint:fix typecheck",
-    "_test": "jest",
+    "lint": "run-s eslint typecheck",
+    "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/openapi-validator/package.json
+++ b/packages/openapi-validator/package.json
@@ -8,10 +8,13 @@
     "build:watch": "tsc --watch",
     "check": "run-s lint test",
     "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
     "eslint": "eslint ./src",
     "eslint:fix": "eslint ./src --fix",
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Overview

This PR adds `clean` NPM script for project's packages. The script is automatically run before `build` and `build:watch` commands.