### PR TITLE
Add TS typings for OpenAPI spec (v3.x)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thank you for submitting a pull request to Fresha API tools.
+-->
+
+## Motivation and Context
+
+What problem does this PR resolve ?
+
+## Type of changes
+
+What types of changes does your code introduce? Put an `x` in all the boxes that apply:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Details
+
+More information on things that require more attention while reviewing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,30 +48,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.18.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.10",
+        "@babel/generator": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.1",
+        "@babel/helper-module-transforms": "^7.19.0",
+        "@babel/helpers": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.10",
-        "@babel/types": "^7.18.10",
+        "@babel/traverse": "^7.19.1",
+        "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -87,12 +87,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.12",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.10",
+        "@babel/types": "^7.19.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -115,14 +115,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.18.8",
+        "@babel/compat-data": "^7.19.1",
         "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.21.3",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -142,13 +142,13 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -189,18 +189,18 @@
         "@babel/helper-simple-access": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -258,14 +258,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -545,19 +545,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-      "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
+        "@babel/generator": "^7.19.0",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.11",
-        "@babel/types": "^7.18.10",
+        "@babel/parser": "^7.19.1",
+        "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-      "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.18.10",
@@ -586,13 +586,13 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -602,6 +602,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
@@ -1121,9 +1124,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1163,9 +1166,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.27",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
-      "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -1219,9 +1222,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-      "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+      "integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -1271,12 +1274,12 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },
@@ -1291,15 +1294,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1315,9 +1318,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-      "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1786,9 +1789,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -1801,10 +1804,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1870,9 +1873,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001374",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true,
       "funding": [
         {
@@ -1910,9 +1913,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "node_modules/cjs-module-lexer": {
@@ -2022,6 +2025,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "node_modules/deep-object-diff": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.7.tgz",
+      "integrity": "sha512-QkgBca0mL08P6HiOjoqvmm6xOAl2W6CT2+34Ljhg0OeFan8cwlcdq8jrLKsBBuUFAZLsN5b6y491KdKEoSo9lg==",
+      "dev": true
+    },
     "node_modules/deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -2095,9 +2104,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2127,15 +2136,15 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
+      "integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.2",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
@@ -2147,9 +2156,9 @@
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
@@ -2301,15 +2310,19 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
       "dependencies": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
+        "debug": "^3.2.7"
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
@@ -2318,67 +2331,6 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -2432,9 +2384,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.8.0.tgz",
-      "integrity": "sha512-IyGhk+PpDgIA99OBPHo+l2aTtt8yAeB1IgPwXOQZSzi8ag/t1MsLZBN2MKL1sj6ahlkaxbkhlm7ll+NPcMcjaQ==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz",
+      "integrity": "sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==",
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
@@ -2592,9 +2544,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -2733,9 +2685,9 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2833,9 +2785,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2909,9 +2861,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -3223,9 +3175,9 @@
       }
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
+      "integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3515,30 +3467,30 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.0.tgz",
+      "integrity": "sha512-rNYfqfLC0L0zQKRKsg4n4J+W1A2fbyGH7Ss/kDIocp9KXD9iaL111glsLu7+Z7FHuZxwzInMDXq+N1ZIBkI/TQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^28.1.0",
+        "@jest/expect": "^28.1.0",
+        "@jest/test-result": "^28.1.0",
+        "@jest/types": "^28.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
+        "jest-each": "^28.1.0",
+        "jest-matcher-utils": "^28.1.0",
+        "jest-message-util": "^28.1.0",
+        "jest-runtime": "^28.1.0",
+        "jest-snapshot": "^28.1.0",
+        "jest-util": "^28.1.0",
+        "pretty-format": "^28.1.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
@@ -3621,6 +3573,36 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-config/node_modules/jest-circus": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/jest-diff": {
@@ -4584,9 +4566,9 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -5213,9 +5195,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
     "node_modules/sprintf-js": {
@@ -5357,9 +5339,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -5415,6 +5397,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "node_modules/throat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5442,9 +5430,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "28.0.7",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
-      "integrity": "sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==",
+      "version": "28.0.8",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
+      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -5581,9 +5569,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5607,9 +5595,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "funding": [
         {
@@ -5746,16 +5734,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/xml": {
@@ -6000,7 +5988,8 @@
     },
     "packages/json-api-model/node_modules/@fresha/api-tools-core": {
       "version": "0.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
+      "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
     },
     "packages/json-schema-codegen": {
       "name": "@fresha/json-schema-codegen",
@@ -6029,7 +6018,8 @@
     },
     "packages/json-schema-model/node_modules/@fresha/api-tools-core": {
       "version": "0.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
+      "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
     },
     "packages/openapi-codegen": {
       "name": "@fresha/openapi-codegen",
@@ -6101,10 +6091,17 @@
       "name": "@fresha/openapi-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@fresha/api-tools-core": "0.1.0",
+        "yaml": "^2.1.1"
+      },
       "devDependencies": {
+        "@fresha/api-tools-core": "0.1.1",
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
+        "@types/node": "^18.0.0",
+        "deep-object-diff": "^1.1.7",
         "typescript": "^4.7.2"
       }
     },
@@ -6141,14 +6138,16 @@
     },
     "tools/ci-config/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "tools/ci-config/node_modules/glob": {
       "version": "8.0.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6165,7 +6164,8 @@
     },
     "tools/ci-config/node_modules/minimatch": {
       "version": "5.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6204,8 +6204,9 @@
     },
     "tools/jest-config/node_modules/@types/jest": {
       "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.0.tgz",
+      "integrity": "sha512-ITfF6JJIl9zbEi2k6NmhNE/BiDqfsI/ceqfvdaWaPbcrCpYyyRq4KtDQIWh6vQUru6SqwppODiom/Zhid+np6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -6213,8 +6214,9 @@
     },
     "tools/jest-config/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6224,16 +6226,18 @@
     },
     "tools/jest-config/node_modules/diff-sequences": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "tools/jest-config/node_modules/jest": {
       "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.0.tgz",
+      "integrity": "sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/core": "^28.1.0",
         "import-local": "^3.0.2",
@@ -6254,102 +6258,11 @@
         }
       }
     },
-    "tools/jest-config/node_modules/jest-circus": {
-      "version": "28.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^28.1.0",
-        "@jest/expect": "^28.1.0",
-        "@jest/test-result": "^28.1.0",
-        "@jest/types": "^28.1.0",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^0.7.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.0",
-        "jest-matcher-utils": "^28.1.0",
-        "jest-message-util": "^28.1.0",
-        "jest-runtime": "^28.1.0",
-        "jest-snapshot": "^28.1.0",
-        "jest-util": "^28.1.0",
-        "pretty-format": "^28.1.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3",
-        "throat": "^6.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/jest-diff": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/jest-matcher-utils": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "tools/jest-config/node_modules/jest-circus/node_modules/react-is": {
-      "version": "18.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "tools/jest-config/node_modules/jest-diff": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.5.1",
@@ -6362,16 +6275,18 @@
     },
     "tools/jest-config/node_modules/jest-get-type": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "tools/jest-config/node_modules/jest-matcher-utils": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^27.5.1",
@@ -6384,8 +6299,9 @@
     },
     "tools/jest-config/node_modules/pretty-format": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6397,13 +6313,15 @@
     },
     "tools/jest-config/node_modules/react-is": {
       "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "tools/jest-config/node_modules/semver": {
       "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6416,8 +6334,9 @@
     },
     "tools/jest-config/node_modules/ts-jest": {
       "version": "28.0.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.4.tgz",
+      "integrity": "sha512-S6uRDDdCJBvnZqyGjB4VCnwbQrbgdL8WPeP4jevVSpYsBaeGRQAIS08o3Svav2Ex+oXwLgJ/m7F24TNq62kA1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
@@ -6454,8 +6373,9 @@
     },
     "tools/jest-config/node_modules/yargs-parser": {
       "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -6487,27 +6407,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.18.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.10",
+        "@babel/generator": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.1",
+        "@babel/helper-module-transforms": "^7.19.0",
+        "@babel/helpers": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.10",
-        "@babel/types": "^7.18.10",
+        "@babel/traverse": "^7.19.1",
+        "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6516,12 +6436,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.12",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.18.10",
+        "@babel/types": "^7.19.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -6540,14 +6460,14 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.18.8",
+        "@babel/compat-data": "^7.19.1",
         "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.21.3",
         "semver": "^6.3.0"
       }
     },
@@ -6558,13 +6478,13 @@
       "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.6",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -6586,9 +6506,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -6596,15 +6516,15 @@
         "@babel/helper-simple-access": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
       "dev": true
     },
     "@babel/helper-simple-access": {
@@ -6632,9 +6552,9 @@
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -6644,14 +6564,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
+      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.0",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/highlight": {
@@ -6724,9 +6644,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -6858,27 +6778,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.18.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-      "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
+        "@babel/generator": "^7.19.0",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.18.11",
-        "@babel/types": "^7.18.10",
+        "@babel/parser": "^7.19.1",
+        "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-      "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.18.10",
@@ -6893,13 +6813,13 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -7041,12 +6961,16 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
           "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -7057,6 +6981,8 @@
         },
         "minimatch": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -7120,6 +7046,8 @@
       "dependencies": {
         "@types/jest": {
           "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.0.tgz",
+          "integrity": "sha512-ITfF6JJIl9zbEi2k6NmhNE/BiDqfsI/ceqfvdaWaPbcrCpYyyRq4KtDQIWh6vQUru6SqwppODiom/Zhid+np6A==",
           "dev": true,
           "requires": {
             "jest-matcher-utils": "^27.0.0",
@@ -7128,14 +7056,20 @@
         },
         "ansi-styles": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
         "diff-sequences": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+          "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
           "dev": true
         },
         "jest": {
           "version": "28.1.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.0.tgz",
+          "integrity": "sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==",
           "dev": true,
           "requires": {
             "@jest/core": "^28.1.0",
@@ -7143,77 +7077,10 @@
             "jest-cli": "^28.1.0"
           }
         },
-        "jest-circus": {
-          "version": "28.1.0",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^28.1.0",
-            "@jest/expect": "^28.1.0",
-            "@jest/test-result": "^28.1.0",
-            "@jest/types": "^28.1.0",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "co": "^4.6.0",
-            "dedent": "^0.7.0",
-            "is-generator-fn": "^2.0.0",
-            "jest-each": "^28.1.0",
-            "jest-matcher-utils": "^28.1.0",
-            "jest-message-util": "^28.1.0",
-            "jest-runtime": "^28.1.0",
-            "jest-snapshot": "^28.1.0",
-            "jest-util": "^28.1.0",
-            "pretty-format": "^28.1.0",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3",
-            "throat": "^6.0.1"
-          },
-          "dependencies": {
-            "diff-sequences": {
-              "version": "28.1.1",
-              "dev": true
-            },
-            "jest-diff": {
-              "version": "28.1.1",
-              "dev": true,
-              "requires": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^28.1.1",
-                "jest-get-type": "^28.0.2",
-                "pretty-format": "^28.1.1"
-              }
-            },
-            "jest-get-type": {
-              "version": "28.0.2",
-              "dev": true
-            },
-            "jest-matcher-utils": {
-              "version": "28.1.1",
-              "dev": true,
-              "requires": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^28.1.1",
-                "jest-get-type": "^28.0.2",
-                "pretty-format": "^28.1.1"
-              }
-            },
-            "pretty-format": {
-              "version": "28.1.1",
-              "dev": true,
-              "requires": {
-                "@jest/schemas": "^28.0.2",
-                "ansi-regex": "^5.0.1",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-              }
-            },
-            "react-is": {
-              "version": "18.2.0",
-              "dev": true
-            }
-          }
-        },
         "jest-diff": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+          "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
@@ -7224,10 +7091,14 @@
         },
         "jest-get-type": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+          "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
           "dev": true
         },
         "jest-matcher-utils": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+          "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
@@ -7238,6 +7109,8 @@
         },
         "pretty-format": {
           "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1",
@@ -7247,10 +7120,14 @@
         },
         "react-is": {
           "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         },
         "semver": {
           "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7258,6 +7135,8 @@
         },
         "ts-jest": {
           "version": "28.0.4",
+          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.4.tgz",
+          "integrity": "sha512-S6uRDDdCJBvnZqyGjB4VCnwbQrbgdL8WPeP4jevVSpYsBaeGRQAIS08o3Svav2Ex+oXwLgJ/m7F24TNq62kA1A==",
           "dev": true,
           "requires": {
             "bs-logger": "0.x",
@@ -7272,6 +7151,8 @@
         },
         "yargs-parser": {
           "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -7297,7 +7178,9 @@
       },
       "dependencies": {
         "@fresha/api-tools-core": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
+          "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
         }
       }
     },
@@ -7321,7 +7204,9 @@
       },
       "dependencies": {
         "@fresha/api-tools-core": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.1.0.tgz",
+          "integrity": "sha512-ftB+NamXDT/gxDZJ4MshCianvufKZHAiSUdbVwHR+0hu52HpJ5WrXx8Ll5YtOZ+1eQ5lv4JcJv1gamjOHHAitg=="
         }
       }
     },
@@ -7382,10 +7267,14 @@
     "@fresha/openapi-model": {
       "version": "file:packages/openapi-model",
       "requires": {
+        "@fresha/api-tools-core": "0.1.1",
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
-        "typescript": "^4.7.2"
+        "@types/node": "^18.0.0",
+        "deep-object-diff": "^1.1.7",
+        "typescript": "^4.7.2",
+        "yaml": "^2.1.1"
       }
     },
     "@fresha/openapi-validator": {
@@ -7684,9 +7573,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -7717,9 +7606,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.27",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.27.tgz",
-      "integrity": "sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==",
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -7773,9 +7662,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-      "integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+      "integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -7825,12 +7714,12 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },
@@ -7845,15 +7734,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "@types/prettier": {
@@ -7869,9 +7758,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-      "integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+      "integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -8174,15 +8063,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "bs-logger": {
@@ -8230,9 +8119,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001374",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-      "integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true
     },
     "chalk": {
@@ -8251,9 +8140,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -8345,6 +8234,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "deep-object-diff": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.7.tgz",
+      "integrity": "sha512-QkgBca0mL08P6HiOjoqvmm6xOAl2W6CT2+34Ljhg0OeFan8cwlcdq8jrLKsBBuUFAZLsN5b6y491KdKEoSo9lg==",
+      "dev": true
+    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -8396,9 +8291,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "emittery": {
@@ -8422,15 +8317,15 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
+      "integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
+        "get-intrinsic": "^1.1.2",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
@@ -8442,9 +8337,9 @@
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
+        "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
@@ -8606,12 +8501,11 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
       "requires": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
+        "debug": "^3.2.7"
       },
       "dependencies": {
         "debug": {
@@ -8621,49 +8515,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
     },
@@ -8711,9 +8562,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.8.0.tgz",
-      "integrity": "sha512-IyGhk+PpDgIA99OBPHo+l2aTtt8yAeB1IgPwXOQZSzi8ag/t1MsLZBN2MKL1sj6ahlkaxbkhlm7ll+NPcMcjaQ==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz",
+      "integrity": "sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==",
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
@@ -8756,9 +8607,9 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
     },
     "espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -8858,9 +8709,9 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -8942,9 +8793,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ=="
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8996,9 +8847,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -9213,9 +9064,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
+      "integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q=="
     },
     "is-core-module": {
       "version": "2.10.0",
@@ -9401,30 +9252,30 @@
       }
     },
     "jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.0.tgz",
+      "integrity": "sha512-rNYfqfLC0L0zQKRKsg4n4J+W1A2fbyGH7Ss/kDIocp9KXD9iaL111glsLu7+Z7FHuZxwzInMDXq+N1ZIBkI/TQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^28.1.0",
+        "@jest/expect": "^28.1.0",
+        "@jest/test-result": "^28.1.0",
+        "@jest/types": "^28.1.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
+        "jest-each": "^28.1.0",
+        "jest-matcher-utils": "^28.1.0",
+        "jest-message-util": "^28.1.0",
+        "jest-runtime": "^28.1.0",
+        "jest-snapshot": "^28.1.0",
+        "jest-util": "^28.1.0",
+        "pretty-format": "^28.1.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
       }
     },
     "jest-cli": {
@@ -9475,6 +9326,35 @@
         "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "jest-circus": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+          "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.3",
+            "@jest/expect": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^0.7.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^28.1.3",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-runtime": "^28.1.3",
+            "jest-snapshot": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "p-limit": "^3.1.0",
+            "pretty-format": "^28.1.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -10235,9 +10115,9 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10665,9 +10545,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
     "sprintf-js": {
@@ -10770,9 +10650,9 @@
       }
     },
     "supports-hyperlinks": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0",
@@ -10810,6 +10690,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
+    "throat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
+      "dev": true
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -10831,9 +10717,9 @@
       }
     },
     "ts-jest": {
-      "version": "28.0.7",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
-      "integrity": "sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==",
+      "version": "28.0.8",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
+      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -10917,9 +10803,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -10933,9 +10819,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
+      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -11032,9 +10918,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",

--- a/packages/openapi-model/docs/index.md
+++ b/packages/openapi-model/docs/index.md
@@ -1,0 +1,4 @@
+# External Links
+
+- https://github.com/OAI/OpenAPI-Specification/tree/main/versions
+- https://github.com/OAI/OpenAPI-Specification/blob/main/IMPLEMENTATIONS.md#implementations

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -37,10 +37,17 @@
     }
   ],
   "license": "MIT",
+  "dependencies": {
+    "@fresha/api-tools-core": "0.1.0",
+    "yaml": "^2.1.1"
+  },
   "devDependencies": {
+    "@fresha/api-tools-core": "0.1.1",
     "@fresha/eslint-config": "0.1.0",
     "@fresha/jest-config": "0.1.0",
     "@fresha/typescript-config": "0.1.0",
+    "@types/node": "^18.0.0",
+    "deep-object-diff": "^1.1.7",
     "typescript": "^4.7.2"
   }
 }

--- a/packages/openapi-model/src/3.0.3/index.ts
+++ b/packages/openapi-model/src/3.0.3/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/openapi-model/src/3.0.3/types.test.ts
+++ b/packages/openapi-model/src/3.0.3/types.test.ts
@@ -1,0 +1,15 @@
+import type { ContactObject } from './types';
+
+test('check ContactObject typings', () => {
+  const contactObject1: ContactObject = {};
+  expect(contactObject1).not.toBeNull();
+
+  const contactObject2: ContactObject = {
+    name: 'a',
+    url: 'http://www.example.com',
+    email: 'me@example.com',
+    'x-ext': 1,
+    // y: 2,
+  };
+  expect(contactObject2).not.toBeNull();
+});

--- a/packages/openapi-model/src/3.0.3/types.ts
+++ b/packages/openapi-model/src/3.0.3/types.ts
@@ -1,0 +1,224 @@
+import type {
+  CallbackObject as CallbackObjectBase,
+  CookieParameterObject as CookieParameterObjectBase,
+  DiscriminatorObject,
+  EncodingObject as EncodingObjectBase,
+  ExampleObject,
+  ExternalDocumentationObject,
+  HeaderParameterObject as HeaderParameterObjectBase,
+  HTTPSecuritySchemeObject as HTTPSecuritySchemeObjectBase,
+  InfoObject,
+  LinkObject,
+  MediaTypeObject as MediaTypeObjectBase,
+  ObjectOrRef,
+  OperationObject as OperationObjectBase,
+  ParameterObject as ParameterObjectBase,
+  PathItemObject as PathItemObjectBase,
+  PathParameterObject as PathParameterObjectBase,
+  PathsObject as PathsObjectBase,
+  QueryParameterObject as QueryParameterObjectBase,
+  RequestBodyObject as RequestBodyObjectBase,
+  ResponseObject as ResponseObjectBase,
+  ResponsesObject as ResponsesObjectBase,
+  SecurityRequirementObject,
+  SecuritySchemeObject as SecuritySchemeObjectBase,
+  ServerObject,
+  SpecificationExtensions,
+  TagObject,
+  XMLObject,
+} from '../baseTypes';
+import type { CommonMarkString, JSONValue } from '@fresha/api-tools-core';
+
+export type {
+  APIKeySecuritySchemeObject,
+  ContactObject,
+  CookieParameterSerializationStyle,
+  ExampleObject,
+  ExternalDocumentationObject,
+  InfoObject,
+  LicenseObject,
+  LinkObject,
+  OAuth2SecuritySchemeObject,
+  OpenIdConnectSecuritySchemeObject,
+  PathParameterSerializationStyle,
+  QueryParameterSerializationStyle,
+  Ref,
+  SecurityRequirementObject,
+  ServerObject,
+  ServerVariableObject,
+  TagObject,
+} from '../baseTypes';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#openapi-object
+ */
+export type OpenAPIObject = {
+  openapi: '3.0.3';
+  info: InfoObject;
+  servers?: ServerObject[];
+  paths: PathsObject;
+  components?: ComponentsObject;
+  security?: SecurityRequirementObject[];
+  tags?: TagObject[];
+  externalDocs?: ExternalDocumentationObject;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#paths-object
+ */
+export type PathsObject = PathsObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#path-item-object
+ */
+export type PathItemObject = PathItemObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#operation-object
+ */
+export type OperationObject = OperationObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type PathParameterObject = PathParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type QueryParameterObject = QueryParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type CookieParameterObject = CookieParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type HeaderParameterObject = HeaderParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ */
+export type ParameterObject = ParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#request-body-object
+ */
+export type RequestBodyObject = RequestBodyObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#media-type-object
+ */
+export type MediaTypeObject = MediaTypeObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#schema-object
+ */
+export type SchemaType = 'boolean' | 'object' | 'array' | 'integer' | 'number' | 'string';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#schema-object
+ */
+export type SchemaFormat =
+  | 'int32'
+  | 'int64'
+  | 'float'
+  | 'double'
+  | 'byte'
+  | 'binary'
+  | 'date'
+  | 'date-time'
+  | 'password';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#schema-object
+ */
+export type SchemaObject = {
+  title?: string;
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  enum?: JSONValue[];
+  type?: SchemaType;
+  allOf?: SchemaObject[];
+  oneOf?: SchemaObject[];
+  anyOf?: SchemaObject[];
+  not?: SchemaObject;
+  items?: SchemaObject;
+  properties?: Record<string, SchemaObject>;
+  additionalProperties?: SchemaObject | boolean;
+  description?: CommonMarkString;
+  format?: SchemaFormat;
+  default?: JSONValue;
+  nullable?: boolean;
+  discriminator?: DiscriminatorObject;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  xml?: XMLObject;
+  externalDocs?: ExternalDocumentationObject;
+  example?: JSONValue;
+  deprecated?: boolean;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#encoding-object
+ */
+export type EncodingObject = EncodingObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#header-object
+ */
+export type HeaderObject = Omit<HeaderParameterObjectBase<SchemaObject>, 'name' | 'in'>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#responses-object
+ */
+export type ResponsesObject = ResponsesObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#response-object
+ */
+export type ResponseObject = ResponseObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#callback-object
+ */
+export type CallbackObject = CallbackObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#components-object
+ */
+export type ComponentsObject = {
+  schemas?: Record<string, ObjectOrRef<SchemaObject>>;
+  responses?: Record<string, ObjectOrRef<ResponseObject>>;
+  parameters?: Record<string, ObjectOrRef<ParameterObject>>;
+  examples?: Record<string, ObjectOrRef<ExampleObject>>;
+  requestBodies?: Record<string, ObjectOrRef<RequestBodyObject>>;
+  headers?: Record<string, ObjectOrRef<HeaderObject>>;
+  securitySchemas?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
+  links?: Record<string, ObjectOrRef<LinkObject>>;
+  callbacks?: Record<string, ObjectOrRef<CallbackObject>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export type HTTPSecuritySchemeObject = HTTPSecuritySchemeObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ */
+export type SecuritySchemeObject = SecuritySchemeObjectBase<SchemaObject>;

--- a/packages/openapi-model/src/3.1.0/index.ts
+++ b/packages/openapi-model/src/3.1.0/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/openapi-model/src/3.1.0/types.ts
+++ b/packages/openapi-model/src/3.1.0/types.ts
@@ -1,0 +1,153 @@
+import type {
+  CallbackObject as CallbackObjectBase,
+  EncodingObject as EncodingObjectBase,
+  ExternalDocumentationObject,
+  HeaderParameterObject as HeaderParameterObjectBase,
+  InfoObject,
+  MediaTypeObject as MediaTypeObjectBase,
+  ObjectOrRef,
+  ParameterObject as ParameterObjectBase,
+  PathsObject as PathsObjectBase,
+  RequestBodyObject as RequestBodyObjectBase,
+  ResponseObject as ResponseObjectBase,
+  ResponsesObject as ResponsesObjectBase,
+  SecurityRequirementObject,
+  SecuritySchemeObject as SecuritySchemeObjectBase,
+  ServerObject,
+  SpecificationExtensions,
+  TagObject,
+  XMLObject,
+  DiscriminatorObject,
+  ExampleObject,
+  LinkObject,
+} from '../baseTypes';
+import type { CommonMarkString, URLString } from '@fresha/api-tools-core';
+
+export type { InfoObject, ContactObject, LicenseObject } from '../baseTypes';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#openapi-object
+ */
+export type OpenAPIObject = {
+  openapi: '3.1.0';
+  info: InfoObject;
+  jsonSchemaDialect?: URLString;
+  servers?: ServerObject[];
+  paths?: PathsObject;
+  webhooks?: Record<string, ObjectOrRef<PathItemObject>>;
+  components?: ComponentsObject;
+  security?: SecurityRequirementObject[];
+  tags?: TagObject[];
+  externalDocs?: ExternalDocumentationObject;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#paths-object
+ */
+export type PathsObject = PathsObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#path-item-object
+ */
+export type PathItemObject = {
+  summary?: string;
+  description?: CommonMarkString;
+  get?: OperationObject;
+  put?: OperationObject;
+  post?: OperationObject;
+  delete?: OperationObject;
+  options?: OperationObject;
+  head?: OperationObject;
+  patch?: OperationObject;
+  trace?: OperationObject;
+  servers?: ServerObject[];
+  parameters?: ObjectOrRef<ParameterObject>[];
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#operation-object
+ */
+export type OperationObject = {
+  tags?: string[];
+  summary?: string;
+  description?: CommonMarkString;
+  externalDocumentation?: ExternalDocumentationObject;
+  operationId?: string;
+  parameters?: ObjectOrRef<ParameterObject>[];
+  requestBody?: ObjectOrRef<RequestBodyObject>;
+  responses: ResponsesObject;
+  callbacks?: Record<string, ObjectOrRef<CallbackObject>>;
+  deprecated?: boolean;
+  security?: SecurityRequirementObject[];
+  servers?: ServerObject[];
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export type ParameterObject = ParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#request-body-object
+ */
+export type RequestBodyObject = RequestBodyObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#mediaTypeObject
+ */
+export type MediaTypeObject = MediaTypeObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#schema-object
+ */
+export type SchemaObject = {
+  type: string[];
+  discriminator?: DiscriminatorObject;
+  xml?: XMLObject;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#encoding-object
+ */
+export type EncodingObject = EncodingObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#header-object
+ */
+export type HeaderObject = HeaderParameterObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#responses-object
+ */
+export type ResponsesObject = ResponsesObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#response-object
+ */
+export type ResponseObject = ResponseObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#callback-object
+ */
+export type CallbackObject = CallbackObjectBase<SchemaObject>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#components-object
+ */
+export type ComponentsObject = {
+  schemas?: Record<string, SchemaObject>;
+  responses?: Record<string, ObjectOrRef<ResponseObject>>;
+  parameters?: Record<string, ObjectOrRef<ParameterObject>>;
+  examples?: Record<string, ObjectOrRef<ExampleObject>>;
+  requestBodies?: Record<string, ObjectOrRef<RequestBodyObject>>;
+  headers?: Record<string, ObjectOrRef<HeaderObject>>;
+  securitySchemas?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
+  links?: Record<string, ObjectOrRef<LinkObject>>;
+  callbacks?: Record<string, ObjectOrRef<CallbackObject>>;
+  pathItems?: Record<string, PathItemObject>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export type SecuritySchemeObject = SecuritySchemeObjectBase<SchemaObject>;

--- a/packages/openapi-model/src/baseTypes.ts
+++ b/packages/openapi-model/src/baseTypes.ts
@@ -1,0 +1,413 @@
+import type { CommonMarkString, JSONValue, URLString } from '@fresha/api-tools-core';
+
+type HTTPStatusCode = number;
+
+export type Ref = {
+  $ref: string;
+};
+
+export type ObjectOrRef<T> = T | Ref;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#specification-extensions
+ * @see https://spec.openapis.org/oas/v3.1.0#specification-extensions
+ */
+export type SpecificationExtensions = {
+  [key: `x-${string}`]: JSONValue;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#info-object
+ * @see https://spec.openapis.org/oas/v3.1.0#info-object
+ */
+export type InfoObject = {
+  title: string;
+  description?: CommonMarkString;
+  termsOfService?: string;
+  contact?: ContactObject;
+  license?: LicenseObject;
+  version: string;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#contact-object
+ * @see https://spec.openapis.org/oas/v3.1.0#contact-object
+ */
+export type ContactObject = {
+  name?: string;
+  url?: string;
+  email?: string;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#license-object
+ * @see https://spec.openapis.org/oas/v3.1.0#license-object
+ */
+export type LicenseObject = {
+  name: string;
+  url?: string;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#server-object
+ * @see https://spec.openapis.org/oas/v3.1.0#server-object
+ */
+export type ServerObject = {
+  url: string;
+  description?: CommonMarkString;
+  variables?: Record<string, ServerVariableObject>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#server-variable-object
+ * @see https://spec.openapis.org/oas/v3.1.0#server-variable-object
+ */
+export type ServerVariableObject = {
+  enum?: string[];
+  default: string;
+  description?: CommonMarkString;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#external-documentation-object
+ * @see https://spec.openapis.org/oas/v3.1.0#external-documentation-object
+ */
+export type ExternalDocumentationObject = {
+  description?: string;
+  url: string;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#tag-object
+ * @see https://spec.openapis.org/oas/v3.1.0#tag-object
+ */
+export type TagObject = {
+  name: string;
+  description?: CommonMarkString;
+  externalDocs?: ExternalDocumentationObject;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-requirement-object
+ * @see https://spec.openapis.org/oas/v3.1.0#security-requirement-object
+ */
+export type SecurityRequirementObject = Record<string, string[]> & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flows-object
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flows-object
+ */
+export type OAuthFlowsObject = {
+  implicit?: OAuthImplicitFlowObject;
+  password?: OAuthPasswordFlowObject;
+  clientCredentials?: OAuthClientCredentialsFlowObject;
+  authorizationCode?: OAuthAuthorizationCodeFlowObject;
+} & SpecificationExtensions;
+
+type _OAuth2FlowObjectCommon = {
+  refreshUrl?: URLString;
+  scopes: Record<string, string>;
+};
+
+export type OAuthImplicitFlowObject = {
+  authorizationUrl: string;
+} & _OAuth2FlowObjectCommon &
+  SpecificationExtensions;
+
+export type OAuthPasswordFlowObject = {
+  tokenUrl: string;
+} & _OAuth2FlowObjectCommon &
+  SpecificationExtensions;
+
+export type OAuthClientCredentialsFlowObject = {
+  tokenUrl: string;
+} & _OAuth2FlowObjectCommon &
+  SpecificationExtensions;
+
+export type OAuthAuthorizationCodeFlowObject = {
+  authorizationUrl: string;
+  tokenUrl: string;
+} & _OAuth2FlowObjectCommon &
+  SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export type OAuthFlowObject =
+  | OAuthImplicitFlowObject
+  | OAuthPasswordFlowObject
+  | OAuthClientCredentialsFlowObject
+  | OAuthAuthorizationCodeFlowObject;
+
+type _SecuritySchemeObjectCommon = {
+  description?: CommonMarkString;
+};
+
+export type APIKeySecuritySchemeObject = {
+  type: 'apiKey';
+  name: string;
+  in: 'query' | 'header' | 'cookie';
+} & _SecuritySchemeObjectCommon &
+  SpecificationExtensions;
+
+export type HTTPSecuritySchemeObject<TScheme> = {
+  type: 'http';
+  scheme: TScheme;
+  bearerFormat?: string;
+} & _SecuritySchemeObjectCommon &
+  SpecificationExtensions;
+
+export type OAuth2SecuritySchemeObject = {
+  type: 'oauth2';
+  flows: OAuthFlowsObject;
+} & _SecuritySchemeObjectCommon &
+  SpecificationExtensions;
+
+export type OpenIdConnectSecuritySchemeObject = {
+  type: 'openIdConnect';
+  openIdConnectUrl: string;
+} & _SecuritySchemeObjectCommon &
+  SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export type SecuritySchemeObject<TScheme> =
+  | APIKeySecuritySchemeObject
+  | HTTPSecuritySchemeObject<TScheme>
+  | OAuth2SecuritySchemeObject
+  | OpenIdConnectSecuritySchemeObject;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#example-object
+ * @see https://spec.openapis.org/oas/v3.1.0#example-object
+ */
+export type ExampleObject = {
+  summary?: string;
+  description?: CommonMarkString;
+  value?: JSONValue;
+  externalValue?: URLString;
+} & SpecificationExtensions;
+
+type _ParameterObjectCommon<TSchema> = {
+  name: string;
+  description?: CommonMarkString;
+  deprecated?: boolean;
+  explode?: boolean;
+  schema?: TSchema;
+  example?: JSONValue;
+  examples?: Record<string, ObjectOrRef<ExampleObject>>;
+  content?: Record<string, MediaTypeObject<TSchema>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#style-values
+ * @see https://spec.openapis.org/oas/v3.1.0#style-values
+ */
+export type PathParameterSerializationStyle = 'matrix' | 'label' | 'simple';
+
+export type PathParameterObject<TSchema> = _ParameterObjectCommon<TSchema> & {
+  in: 'path';
+  required: true;
+  style?: PathParameterSerializationStyle;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#style-values
+ * @see https://spec.openapis.org/oas/v3.1.0#style-values
+ */
+export type QueryParameterSerializationStyle =
+  | 'form'
+  | 'spaceDelimited'
+  | 'pipeDelimited'
+  | 'deepObject';
+
+export type QueryParameterObject<TSchema> = _ParameterObjectCommon<TSchema> & {
+  in: 'query';
+  required?: boolean;
+  allowEmptyValue?: boolean;
+  style?: QueryParameterSerializationStyle;
+  allowReserved?: boolean;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#style-values
+ * @see https://spec.openapis.org/oas/v3.1.0#style-values
+ */
+export type HeaderParameterSerializationStyle = 'simple';
+
+export type HeaderParameterObject<TSchema> = _ParameterObjectCommon<TSchema> & {
+  in: 'header';
+  required?: boolean;
+  style?: HeaderParameterSerializationStyle;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#style-values
+ * @see https://spec.openapis.org/oas/v3.1.0#style-values
+ */
+export type CookieParameterSerializationStyle = 'form';
+
+export type CookieParameterObject<TSchema> = _ParameterObjectCommon<TSchema> & {
+  in: 'cookie';
+  required?: boolean;
+  style?: CookieParameterSerializationStyle;
+};
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#parameter-object
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export type ParameterObject<TSchema> =
+  | PathParameterObject<TSchema>
+  | QueryParameterObject<TSchema>
+  | HeaderParameterObject<TSchema>
+  | CookieParameterObject<TSchema>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#media-type-object
+ * @see https://spec.openapis.org/oas/v3.1.0#media-type-object
+ */
+export type MediaTypeObject<TSchema> = {
+  schema?: ObjectOrRef<TSchema>;
+  example?: JSONValue;
+  examples?: Record<string, ObjectOrRef<ExampleObject>>;
+  encoding?: Record<string, EncodingObject<TSchema>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#header-object
+ * @see https://spec.openapis.org/oas/v3.1.0#header-object
+ */
+export type HeaderObject<TSchema> = Omit<HeaderParameterObject<TSchema>, 'name' | 'in'>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#encoding-object
+ * @see https://spec.openapis.org/oas/v3.1.0#encoding-object
+ */
+export type EncodingObject<TSchema> = {
+  contentType?: string;
+  headers?: Record<string, ObjectOrRef<HeaderObject<TSchema>>>;
+  style?: QueryParameterSerializationStyle;
+  explode?: boolean;
+  allowReserved?: boolean;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#request-body-object
+ * @see https://spec.openapis.org/oas/v3.1.0#request-body-object
+ */
+export type RequestBodyObject<TSchema> = {
+  description?: CommonMarkString;
+  content: Record<string, MediaTypeObject<TSchema>>;
+  required?: boolean;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#discriminator-object
+ * @see https://spec.openapis.org/oas/v3.1.0#discriminator-object
+ */
+export type DiscriminatorObject = {
+  propertyName: string;
+  mapping?: Record<string, string>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#xml-object
+ * @see https://spec.openapis.org/oas/v3.1.0#xml-object
+ */
+export type XMLObject = {
+  name?: string;
+  namespace?: URLString;
+  prefix?: string;
+  attribute?: boolean;
+  wrapped?: boolean;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#responses-object
+ * @see https://spec.openapis.org/oas/v3.1.0#responses-object
+ */
+export type ResponsesObject<TSchema> = {
+  default?: ObjectOrRef<ResponseObject<TSchema>>;
+  [statusCode: HTTPStatusCode]: ObjectOrRef<ResponseObject<TSchema>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#response-object
+ * @see https://spec.openapis.org/oas/v3.1.0#response-object
+ */
+export type ResponseObject<TSchema> = {
+  description: CommonMarkString;
+  headers?: Record<string, ObjectOrRef<HeaderObject<TSchema>>>;
+  content?: Record<string, ObjectOrRef<MediaTypeObject<TSchema>>>;
+  links?: Record<string, ObjectOrRef<LinkObject>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#link-object
+ * @see https://spec.openapis.org/oas/v3.1.0#link-object
+ */
+export type LinkObject = {
+  operationRef?: URLString;
+  operationId?: string;
+  parameters?: Record<string, JSONValue>;
+  requestBody?: JSONValue;
+  description?: CommonMarkString;
+  server?: ServerObject;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#callback-object
+ * @see https://spec.openapis.org/oas/v3.1.0#callback-object
+ */
+export type CallbackObject<TSchema> = Record<string, PathItemObject<TSchema>> &
+  SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#paths-object
+ * @see https://spec.openapis.org/oas/v3.1.0#paths-object
+ */
+export type PathsObject<TSchema> = {
+  [pathUrl: string]: ObjectOrRef<PathItemObject<TSchema>>;
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#path-item-object
+ * @see https://spec.openapis.org/oas/v3.1.0#path-item-object
+ */
+export type PathItemObject<TSchema> = {
+  summary?: string;
+  description?: CommonMarkString;
+  get?: OperationObject<TSchema>;
+  put?: OperationObject<TSchema>;
+  post?: OperationObject<TSchema>;
+  delete?: OperationObject<TSchema>;
+  options?: OperationObject<TSchema>;
+  head?: OperationObject<TSchema>;
+  patch?: OperationObject<TSchema>;
+  trace?: OperationObject<TSchema>;
+  servers?: ServerObject[];
+  parameters?: ObjectOrRef<ParameterObject<TSchema>>[];
+} & SpecificationExtensions;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#operation-object
+ * @see https://spec.openapis.org/oas/v3.1.0#operation-object
+ */
+export type OperationObject<TSchema> = {
+  tags?: string[];
+  summary?: string;
+  description?: CommonMarkString;
+  externalDocumentation?: ExternalDocumentationObject;
+  operationId?: string;
+  parameters?: ObjectOrRef<ParameterObject<TSchema>>[];
+  requestBody?: ObjectOrRef<RequestBodyObject<TSchema>>;
+  responses: ResponsesObject<TSchema>;
+  callbacks?: Record<string, ObjectOrRef<CallbackObject<TSchema>>>;
+  deprecated?: boolean;
+  security?: SecurityRequirementObject[];
+  servers?: ServerObject[];
+} & SpecificationExtensions;

--- a/packages/openapi-model/src/index.test.ts
+++ b/packages/openapi-model/src/index.test.ts
@@ -1,3 +1,0 @@
-test('dummy', () => {
-  expect(2 + 2).toBe(4);
-});

--- a/packages/openapi-model/src/index.ts
+++ b/packages/openapi-model/src/index.ts
@@ -1,0 +1,2 @@
+export * as v3_0_3 from './3.0.3'; // eslint-disable-line camelcase
+export * as v3_1_0 from './3.1.0'; // eslint-disable-line camelcase


### PR DESCRIPTION
## Motivation and Context

This PR adds TypeScript typings for structures defined in OpenAPI specifications v3.0 and v3.1. Typings will be part of the `@fresha/openapi-model` package.

## Details

None