### PR TITLE
Prepare to publish openapi-model@0.1.0

### DIFF
--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -18,6 +18,12 @@
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
+  "files": [
+    "build/",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "keywords": [
     "OpenAPI"
   ],


### PR DESCRIPTION
## Motivation and Context

This PR defines `files` in `package.json` of the `@fresha/openapi-model`, so that only transpiled files are included in the release.

## Details

None.