### PR TITLE
Extend @fresha/jest-config with custom matcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,36 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -1292,6 +1322,48 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.185",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.camelcase": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.camelcase/-/lodash.camelcase-4.3.7.tgz",
+      "integrity": "sha512-Nfi6jpo9vuEOSIJP+mpbTezKyEt75DQlbwjiDvs/JctWkbnHDoyQo5lWqdvgNiJmVUjcmkfvlrvSEgJYvurOKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.get": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.7.tgz",
+      "integrity": "sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.kebabcase": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.7.tgz",
+      "integrity": "sha512-qzrcpK5uiADZ9OyZaegalM0b9Y3WetoBQ04RAtP3xZFGC5ul1UxmbjZ3j6suCh0BDkvgQmoMh8t5e9cVrdJYMw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.startcase": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.startcase/-/lodash.startcase-4.4.7.tgz",
+      "integrity": "sha512-6v8FVOcfxdomO1Vammc1Zsah7/4aif/Lx16oQQ0WZmKVGF/Yf5c5m68LqI/ELOhKaKUr8KfnDdKrytdrThoRQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -1873,9 +1945,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001409",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
+      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
       "dev": true,
       "funding": [
         {
@@ -1943,6 +2015,11 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -2055,6 +2132,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2103,10 +2191,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dprint-node": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.7.tgz",
+      "integrity": "sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.256",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz",
+      "integrity": "sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4162,6 +4258,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4172,6 +4283,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4278,7 +4394,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -4699,6 +4814,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5451,6 +5571,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/ts-morph": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
+      "dependencies": {
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
+      }
+    },
+    "node_modules/ts-poet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.1.0.tgz",
+      "integrity": "sha512-PFwbNJjGrb44wzHUGQicG2/nhjR+3+k7zYLDTa8D61NVUitl7K/JgIc9/P+8oMNenntKzLc8tjLDOkPrxIhm6A==",
+      "dependencies": {
+        "dprint-node": "^1.0.7"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5987,10 +6124,18 @@
       "name": "@fresha/openapi-codegen",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@fresha/openapi-codegen-server-nestjs": "^0.1.0",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "fresha-openapi-codegen": "bin/fresha-openapi-codegen.js"
+      },
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
+        "@types/yargs": "^17.0.12",
         "typescript": "^4.7.2"
       }
     },
@@ -6020,11 +6165,26 @@
       "name": "@fresha/openapi-codegen-server-nestjs",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@fresha/openapi-model": "0.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.get": "^4.4.2",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "ts-morph": "^16.0.0",
+        "ts-poet": "^6.1.0",
+        "typescript": "^4.7.2",
+        "yaml": "^2.1.1"
+      },
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
-        "typescript": "^4.7.2"
+        "@types/lodash.camelcase": "^4.3.7",
+        "@types/lodash.get": "^4.4.7",
+        "@types/lodash.kebabcase": "^4.1.7",
+        "@types/lodash.startcase": "^4.4.7",
+        "@types/yargs": "^17.0.12"
       }
     },
     "packages/openapi-diff": {
@@ -6153,12 +6313,18 @@
     "tools/jest-config": {
       "name": "@fresha/jest-config",
       "version": "0.1.0",
+      "dependencies": {
+        "prettier": "^2.7.1"
+      },
       "devDependencies": {
+        "@fresha/eslint-config": "0.1.0",
+        "@fresha/typescript-config": "0.1.0",
         "@types/jest": "28.1.0",
         "jest": "28.1.0",
         "jest-circus": "28.1.0",
         "jest-junit": "13.2.0",
         "ts-jest": "28.0.4",
+        "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
       }
     },
@@ -6340,6 +6506,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "tools/jest-config/node_modules/prettier": {
+      "version": "2.7.1",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "tools/jest-config/node_modules/pretty-format": {
@@ -7070,11 +7249,15 @@
     "@fresha/jest-config": {
       "version": "file:tools/jest-config",
       "requires": {
+        "@fresha/eslint-config": "0.1.0",
+        "@fresha/typescript-config": "0.1.0",
         "@types/jest": "28.1.0",
         "jest": "28.1.0",
         "jest-circus": "28.1.0",
         "jest-junit": "13.2.0",
+        "prettier": "^2.7.1",
         "ts-jest": "28.0.4",
+        "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
       },
       "dependencies": {
@@ -7196,6 +7379,9 @@
             "pretty-format": "^27.5.1"
           }
         },
+        "prettier": {
+          "version": "2.7.1"
+        },
         "pretty-format": {
           "version": "27.5.1",
           "dev": true,
@@ -7290,8 +7476,11 @@
       "requires": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
+        "@fresha/openapi-codegen-server-nestjs": "^0.1.0",
         "@fresha/typescript-config": "0.1.0",
-        "typescript": "^4.7.2"
+        "@types/yargs": "^17.0.12",
+        "typescript": "^4.7.2",
+        "yargs": "^17.5.1"
       }
     },
     "@fresha/openapi-codegen-client-typescript": {
@@ -7317,8 +7506,21 @@
       "requires": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
+        "@fresha/openapi-model": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
-        "typescript": "^4.7.2"
+        "@types/lodash.camelcase": "^4.3.7",
+        "@types/lodash.get": "^4.4.7",
+        "@types/lodash.kebabcase": "^4.1.7",
+        "@types/lodash.startcase": "^4.4.7",
+        "@types/yargs": "^17.0.12",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.get": "^4.4.2",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "ts-morph": "^16.0.0",
+        "ts-poet": "^6.1.0",
+        "typescript": "^4.7.2",
+        "yaml": "^2.1.1"
       }
     },
     "@fresha/openapi-diff": {
@@ -7705,6 +7907,35 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@ts-morph/common": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.17.0.tgz",
+      "integrity": "sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==",
+      "requires": {
+        "fast-glob": "^3.2.11",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -7808,6 +8039,48 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "@types/lodash": {
+      "version": "4.14.185",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
+      "dev": true
+    },
+    "@types/lodash.camelcase": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.camelcase/-/lodash.camelcase-4.3.7.tgz",
+      "integrity": "sha512-Nfi6jpo9vuEOSIJP+mpbTezKyEt75DQlbwjiDvs/JctWkbnHDoyQo5lWqdvgNiJmVUjcmkfvlrvSEgJYvurOKg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.get": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.7.tgz",
+      "integrity": "sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.kebabcase": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.7.tgz",
+      "integrity": "sha512-qzrcpK5uiADZ9OyZaegalM0b9Y3WetoBQ04RAtP3xZFGC5ul1UxmbjZ3j6suCh0BDkvgQmoMh8t5e9cVrdJYMw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.startcase": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.startcase/-/lodash.startcase-4.4.7.tgz",
+      "integrity": "sha512-6v8FVOcfxdomO1Vammc1Zsah7/4aif/Lx16oQQ0WZmKVGF/Yf5c5m68LqI/ELOhKaKUr8KfnDdKrytdrThoRQw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/minimatch": {
       "version": "5.1.2",
@@ -8195,9 +8468,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001409",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
+      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
       "dev": true
     },
     "chalk": {
@@ -8242,6 +8515,11 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
+    },
+    "code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -8331,6 +8609,11 @@
         "object-keys": "^1.1.1"
       }
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -8366,10 +8649,18 @@
         "esutils": "^2.0.2"
       }
     },
+    "dprint-node": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.7.tgz",
+      "integrity": "sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==",
+      "requires": {
+        "detect-libc": "^1.0.3"
+      }
+    },
     "electron-to-chromium": {
-      "version": "1.4.254",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
-      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
+      "version": "1.4.256",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz",
+      "integrity": "sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==",
       "dev": true
     },
     "emittery": {
@@ -9870,6 +10161,21 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9880,6 +10186,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -9961,8 +10272,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "ms": {
       "version": "2.1.2",
@@ -10276,6 +10586,11 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",
@@ -10782,6 +11097,23 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "ts-morph": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-16.0.0.tgz",
+      "integrity": "sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==",
+      "requires": {
+        "@ts-morph/common": "~0.17.0",
+        "code-block-writer": "^11.0.3"
+      }
+    },
+    "ts-poet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.1.0.tgz",
+      "integrity": "sha512-PFwbNJjGrb44wzHUGQicG2/nhjR+3+k7zYLDTa8D61NVUitl7K/JgIc9/P+8oMNenntKzLc8tjLDOkPrxIhm6A==",
+      "requires": {
+        "dprint-node": "^1.0.7"
       }
     },
     "tsconfig-paths": {

--- a/tools/jest-config/.eslintrc
+++ b/tools/jest-config/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": ["@fresha"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": ["./tsconfig.eslint.json"]
+  }
+}

--- a/tools/jest-config/package.json
+++ b/tools/jest-config/package.json
@@ -2,6 +2,21 @@
   "name": "@fresha/jest-config",
   "version": "0.1.0",
   "description": "Common Jest configuration for this project",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "check": "run-s lint test",
+    "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
+    "eslint": "eslint ./src",
+    "eslint:fix": "eslint ./src --fix",
+    "lint": "run-s eslint typecheck",
+    "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
+    "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
   "author": "Fresha Engineering",
   "contributors": [
     {
@@ -17,13 +32,20 @@
       "url": "https://github.com/mykulyak"
     }
   ],
-  "main": "src/index.js",
+  "main": "build/index.js",
+  "types": "build/types.d.ts",
+  "dependencies": {
+    "prettier": "^2.7.1"
+  },
   "devDependencies": {
+    "@fresha/eslint-config": "0.1.0",
+    "@fresha/typescript-config": "0.1.0",
     "@types/jest": "28.1.0",
     "jest": "28.1.0",
     "jest-circus": "28.1.0",
     "jest-junit": "13.2.0",
     "ts-jest": "28.0.4",
+    "ts-morph": "^16.0.0",
     "typescript": "^4.7.2"
   }
 }

--- a/tools/jest-config/src/index.ts
+++ b/tools/jest-config/src/index.ts
@@ -1,4 +1,6 @@
-module.exports = {
+import path from 'path';
+
+export default {
   clearMocks: true,
   coverageDirectory: '/tmp/coverage',
   coverageProvider: 'v8',
@@ -14,10 +16,9 @@ module.exports = {
     'default',
     ['jest-junit', { outputDirectory: '/tmp/test-results', outputName: 'test-results.xml' }],
   ],
+  setupFilesAfterEnv: [path.join(__dirname, 'setupEnv.js')],
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
   testRunner: 'jest-circus/runner',
-  transformIgnorePatterns: [
-    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
-  ],
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$'],
 };

--- a/tools/jest-config/src/setupEnv.ts
+++ b/tools/jest-config/src/setupEnv.ts
@@ -1,0 +1,30 @@
+import * as prettier from 'prettier';
+
+import type { SourceFile } from 'ts-morph';
+
+expect.extend({
+  toHaveFormattedText: (
+    sourceFile: SourceFile,
+    textToCompare: string,
+  ): jest.CustomMatcherResult => {
+    const options: prettier.Options = {
+      parser: 'typescript',
+      singleQuote: true,
+      trailingComma: 'all',
+    };
+    const thisText = prettier.format(sourceFile.getText(), options);
+    const otherText = prettier.format(textToCompare, options);
+
+    if (thisText !== otherText) {
+      return {
+        pass: false,
+        message: () => `Source text differs. Expected '${otherText}', got '${thisText}'`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () => 'Source text is the same',
+    };
+  },
+});

--- a/tools/jest-config/src/types.ts
+++ b/tools/jest-config/src/types.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line  @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
+declare namespace jest {
+  interface Matchers<R> {
+    toHaveFormattedText(text: string): R;
+  }
+}

--- a/tools/jest-config/tsconfig.eslint.json
+++ b/tools/jest-config/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}

--- a/tools/jest-config/tsconfig.json
+++ b/tools/jest-config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@fresha/typescript-config",
+  "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/*.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Motivation and Context

There's a need of externalising test matcher code from packages that use it. For example, we need to test whether the source code text generated by our tools is the same as expected.

This PR extends @fresha/jest-config with a toHaveFormattedCode() matcher, which compares 2 versions of source code (to minimise the amount of false positives, it uses prettier to normalise the code).
