### PR TITLE
Extend/fix @fresha/openapi-model

### DIFF
--- a/packages/openapi-model/examples/json-api.yaml
+++ b/packages/openapi-model/examples/json-api.yaml
@@ -1,0 +1,179 @@
+openapi: 3.0.3
+info:
+  title: json-api-with-shared-objects
+  description: JSON:API contract with shared request bodies and responses
+  contact:
+    name: developers
+    url: https://github.com/orgs/surgeventures/teams/developers
+  version: 0.1.0
+servers:
+  - url: http://localhost:{port}
+    description: local
+    variables:
+      port:
+        default: "8791"
+paths:
+  x-root-url: API_URL
+  /features:
+    get:
+      operationId: readFeatures
+      x-entry-key: features
+      responses:
+        default:
+          $ref: "#/components/responses/JSONAPIDataResponse"
+  /provider:
+    get:
+      operationId: readProvider
+      x-entry-key: provider
+      responses:
+        default:
+          $ref: "#/components/responses/JSONAPIDataResponse"
+  /provider/account-settings:
+    put:
+      operationId: updateProviderAccountSettings
+      x-entry-key: provider
+      requestBody:
+        $ref: "#/components/requestBodies/JSONAPIRequest"
+      responses:
+        default:
+          $ref: "#/components/responses/JSONAPIDataResponse"
+components:
+  schemas:
+    JSONAPIVersion:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: string
+          default: "1.0"
+          enum:
+            - "1.0"
+    JSONAPIResourceId:
+      type: object
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+    JSONAPIResourceIdList:
+      type: array
+      items:
+        $ref: "#/components/schemas/JSONAPIResourceId"
+    JSONAPIRelationship:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/JSONAPIResourceId"
+            - $ref: "#/components/schemas/JSONAPIResourceIdList"
+    JSONAPIResource:
+      type: object
+      required:
+        - type
+        - id
+        - attributes
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        attributes:
+          type: object
+        relationships:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/JSONAPIRelationship"
+    JSONAPIResourceList:
+      type: array
+      items:
+        $ref: "#/components/schemas/JSONAPIResource"
+    JSONAPIDataDocument:
+      type: object
+      required:
+        - data
+      properties:
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPIVersion"
+        data:
+          oneOf:
+            - $ref: "#/components/schemas/JSONAPIResourceId"
+            - $ref: "#/components/schemas/JSONAPIResourceIdList"
+            - $ref: "#/components/schemas/JSONAPIResource"
+            - $ref: "#/components/schemas/JSONAPIResourceList"
+        included:
+          type: array
+          items:
+            $ref: "#/components/schemas/JSONAPIResource"
+    JSONAPIError:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        code:
+          type: string
+        title:
+          type: string
+        detail:
+          type: string
+        source:
+          type: object
+          properties:
+            pointer:
+              type: string
+            parameter:
+              type: string
+    JSONAPIErrorList:
+      type: array
+      items:
+        $ref: "#/components/schemas/JSONAPIError"
+    JSONAPIErrorDocument:
+      type: object
+      required:
+        - errors
+      properties:
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPIVersion"
+        errors:
+          $ref: "#/components/schemas/JSONAPIErrorList"
+  requestBodies:
+    JSONAPIRequest:
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JSONAPIDataDocument"
+      required: true
+  responses:
+    JSONAPIDataResponse:
+      description: Generic success response
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JSONAPIDataDocument"
+    JSONAPIErrorResponse:
+      description: Generic error response
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JSONAPIErrorDocument"
+  securitySchemes:
+    cookieAuthStaging:
+      description: Use this if you connect to staging environment
+      type: apiKey
+      in: cookie
+      name: _partners_session_staging
+    cookieAuthProduction:
+      description: Use this if you connect to production
+      type: apiKey
+      in: cookie
+      name: _partners_session
+security:
+  - cookieAuthStaging: []
+    cookieAuthProduction: []

--- a/packages/openapi-model/src/3.0.3/model/Components.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.test.ts
@@ -191,30 +191,30 @@ describe('headers', () => {
   });
 });
 
-describe('securitySchemas', () => {
+describe('securitySchemes', () => {
   beforeEach(() => {
     components.setSecuritySchema('local', 'apiKey');
     components.setSecuritySchema('google', 'oauth2');
   });
 
   test('setSecuritySchema', () => {
-    expect(components.securitySchemas.size).toBe(2);
-    expect(components.securitySchemas.get('local')).toHaveProperty('parent', components);
-    expect(components.securitySchemas.get('google')).toHaveProperty('parent', components);
+    expect(components.securitySchemes.size).toBe(2);
+    expect(components.securitySchemes.get('local')).toHaveProperty('parent', components);
+    expect(components.securitySchemes.get('google')).toHaveProperty('parent', components);
   });
 
   test('deleteSecuritySchema', () => {
     components.deleteSecuritySchema('local');
 
-    expect(components.securitySchemas.size).toBe(1);
-    expect(components.securitySchemas.get('google')).toBeTruthy();
-    expect(components.securitySchemas.get('google')).toHaveProperty('type', 'oauth2');
+    expect(components.securitySchemes.size).toBe(1);
+    expect(components.securitySchemes.get('google')).toBeTruthy();
+    expect(components.securitySchemes.get('google')).toHaveProperty('type', 'oauth2');
   });
 
-  test('clearSecuritySchemas', () => {
-    components.clearSecuritySchemas();
+  test('clearsecuritySchemes', () => {
+    components.clearSecuritySchemes();
 
-    expect(components.securitySchemas.size).toBe(0);
+    expect(components.securitySchemes.size).toBe(0);
   });
 });
 

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -44,7 +44,7 @@ export class Components extends BasicNode<OpenAPI> implements ComponentsModel {
   readonly examples: Map<string, Example>;
   readonly requestBodies: Map<string, RequestBody>;
   readonly headers: Map<string, Header>;
-  readonly securitySchemas: Map<string, SecurityScheme>;
+  readonly securitySchemes: Map<string, SecurityScheme>;
   readonly links: Map<string, Link>;
   readonly callbacks: Map<string, Callback>;
 
@@ -56,7 +56,7 @@ export class Components extends BasicNode<OpenAPI> implements ComponentsModel {
     this.examples = new Map<string, Example>();
     this.requestBodies = new Map<string, RequestBody>();
     this.headers = new Map<string, Header>();
-    this.securitySchemas = new Map<string, SecurityScheme>();
+    this.securitySchemes = new Map<string, SecurityScheme>();
     this.links = new Map<string, Link>();
     this.callbacks = new Map<string, Callback>();
   }
@@ -69,7 +69,7 @@ export class Components extends BasicNode<OpenAPI> implements ComponentsModel {
       !this.examples.size &&
       !this.requestBodies.size &&
       !this.headers.size &&
-      !this.securitySchemas.size &&
+      !this.securitySchemes.size &&
       !this.links.size &&
       !this.callbacks.size
     );
@@ -193,16 +193,16 @@ export class Components extends BasicNode<OpenAPI> implements ComponentsModel {
       default:
         throw new Error(`Unsupported security scheme type ${String(kind)}`);
     }
-    this.securitySchemas.set(name, result);
+    this.securitySchemes.set(name, result);
     return result;
   }
 
   deleteSecuritySchema(name: string): void {
-    this.securitySchemas.delete(name);
+    this.securitySchemes.delete(name);
   }
 
-  clearSecuritySchemas(): void {
-    this.securitySchemas.clear();
+  clearSecuritySchemes(): void {
+    this.securitySchemes.clear();
   }
 
   setLink(name: string): LinkModel {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -15,6 +15,7 @@ import type {
   PathItemModel,
   TagModel,
   SpecificationExtensionsModel,
+  OpenAPIModelFactory,
 } from './types';
 import type { CommonMarkString, Nullable, VersionString, JSONValue } from '@fresha/api-tools-core';
 
@@ -22,6 +23,12 @@ import type { CommonMarkString, Nullable, VersionString, JSONValue } from '@fres
  * @see http://spec.openapis.org/oas/v3.0.3#openapi-object
  */
 export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
+  static create(): OpenAPI;
+  static create(title: string, version: string): OpenAPI;
+  static create(title?: string, version?: string): OpenAPI {
+    return new OpenAPI(title ?? 'New API', version ?? '0.1.0');
+  }
+
   readonly openapi: OpenApiVersion;
   info: Info;
   servers: ServerImpl[];
@@ -129,3 +136,5 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
   // eslint-disable-next-line class-methods-use-this
   dispose(): void {}
 }
+
+export const OpenAPIFactory: OpenAPIModelFactory = OpenAPI;

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
@@ -45,9 +45,9 @@ describe('SchemaModel', () => {
     expect(emptySchema).toHaveProperty('title', null);
     expect(emptySchema).toHaveProperty('multipleOf', null);
     expect(emptySchema).toHaveProperty('maximum', null);
-    expect(emptySchema).toHaveProperty('exclusiveMaximum', false);
+    expect(emptySchema).toHaveProperty('exclusiveMaximum', null);
     expect(emptySchema).toHaveProperty('minimum', null);
-    expect(emptySchema).toHaveProperty('exclusiveMinimum', false);
+    expect(emptySchema).toHaveProperty('exclusiveMinimum', null);
     expect(emptySchema).toHaveProperty('minLength', null);
     expect(emptySchema).toHaveProperty('maxLength', null);
     expect(emptySchema).toHaveProperty('pattern', null);
@@ -96,9 +96,9 @@ describe('SchemaModel', () => {
             title: 'error message schema',
             multipleOf: 4,
             maximum: 100,
-            exclusiveMaximum: true,
+            exclusiveMaximum: 99,
             minimum: 10,
-            exclusiveMinimum: false,
+            exclusiveMinimum: 11,
             minLength: 5,
             maxLength: 25,
             pattern: '*',
@@ -153,9 +153,9 @@ describe('SchemaModel', () => {
     expect(errorMessageSchema).toHaveProperty('title', 'error message schema');
     expect(errorMessageSchema).toHaveProperty('multipleOf', 4);
     expect(errorMessageSchema).toHaveProperty('maximum', 100);
-    expect(errorMessageSchema).toHaveProperty('exclusiveMaximum', true);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMaximum', 99);
     expect(errorMessageSchema).toHaveProperty('minimum', 10);
-    expect(errorMessageSchema).toHaveProperty('exclusiveMinimum', false);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMinimum', 11);
     expect(errorMessageSchema).toHaveProperty('minLength', 5);
     expect(errorMessageSchema).toHaveProperty('maxLength', 25);
     expect(errorMessageSchema).toHaveProperty('pattern', '*');

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
@@ -82,7 +82,7 @@ test('serialises operation with inline schemas', () => {
   const openapi = new OpenAPI('Operation test', '0.1.0');
 
   const pathItem = openapi.setPathItem('/employees');
-  const operation = pathItem.addOperation('post');
+  const operation = pathItem.setOperation('post');
   const response = operation.responses.setDefaultResponse('Error response');
   const responseMediaType = response.setContent('application/json') as MediaType;
   const responseSchema = responseMediaType.setSchema('object');
@@ -124,7 +124,7 @@ test('serialises operation with shared schemas', () => {
 
   const employeesPathItem = openapi.setPathItem('/employees');
 
-  const createEmployeeOperation = employeesPathItem.addOperation('post');
+  const createEmployeeOperation = employeesPathItem.setOperation('post');
   const createEmployeeResponse =
     createEmployeeOperation.responses.setDefaultResponse('Error response');
   const createEmployeeResponseJson = createEmployeeResponse.setContent('application/json');
@@ -165,19 +165,22 @@ test('serialises operation with shared schemas', () => {
   });
 });
 
-test.each(['api', 'callback', 'link', 'petstore', 'simple', 'uspto'])('example - %s', stem => {
-  const reader = new OpenAPIReader();
+test.each(['api', 'callback', 'link', 'petstore', 'simple', 'uspto', 'json-api'])(
+  'example - %s',
+  stem => {
+    const reader = new OpenAPIReader();
 
-  const inputText = fs.readFileSync(
-    path.join(__dirname, '..', '..', '..', 'examples', `${stem}.yaml`),
-    'utf-8',
-  );
-  const inputData = yaml.parse(inputText) as OpenAPIObject;
+    const inputText = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'examples', `${stem}.yaml`),
+      'utf-8',
+    );
+    const inputData = yaml.parse(inputText) as OpenAPIObject;
 
-  const openapi = reader.parse(inputData);
+    const openapi = reader.parse(inputData);
 
-  const writer = new OpenAPIWriter();
-  const outputData = writer.write(openapi);
+    const writer = new OpenAPIWriter();
+    const outputData = writer.write(openapi);
 
-  expect(outputData).toStrictEqual(inputData);
-});
+    expect(outputData).toStrictEqual(inputData);
+  },
+);

--- a/packages/openapi-model/src/3.0.3/model/PathItem.ts
+++ b/packages/openapi-model/src/3.0.3/model/PathItem.ts
@@ -108,7 +108,7 @@ export class PathItem extends BasicNode<PathItemParent> implements PathItemModel
     return this.operations2.get('trace') ?? null;
   }
 
-  addOperation(method: HTTPMethod): OperationModel {
+  setOperation(method: HTTPMethod): OperationModel {
     if (this.operations2.has(method)) {
       throw new Error(`Duplicate ${method} operation`);
     }

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -32,7 +32,7 @@ describe('SchemaFactory', () => {
     expect(stringArraySchema.items?.type).toBe('string');
 
     const numberArraySchema = SchemaFactory.createArray(openapi.components, {
-      type: 'number',
+      itemsOptions: 'number',
       minItems: 10,
       maxItems: 12,
     });
@@ -191,6 +191,54 @@ describe('Schema', () => {
     schema.clearAllOf();
 
     expect(schema.allOf).toBeNull();
+  });
+
+  test('addOneOf', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, null);
+    expect(schema.allOf).toBeNull();
+
+    const option1 = schema.addOneOf('integer');
+
+    const anotherSchema = SchemaFactory.create(openapi.components, null);
+    const option2 = schema.addOneOf(anotherSchema);
+
+    expect(option1).toHaveProperty('parent', schema);
+    expect(option2).toBe(anotherSchema);
+
+    expect(schema.oneOf?.length).toBe(2);
+    expect(schema.oneOf?.[0]).toBe(option1);
+    expect(schema.oneOf?.[1]).toBe(option2);
+  });
+
+  test('deleteOneOfAt', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const schema = SchemaFactory.create(openapi.components, null);
+    schema.addOneOf('integer');
+    schema.addOneOf('double');
+
+    schema.deleteOneOfAt(0);
+
+    expect(schema.oneOf).toHaveLength(1);
+    expect(schema.oneOf?.[0]).toHaveProperty('type', 'number');
+
+    schema.deleteOneOfAt(0);
+
+    expect(schema.oneOf).toBeNull();
+  });
+
+  test('clearOneOf', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const schema = SchemaFactory.create(openapi.components, null);
+    schema.addOneOf('integer');
+    schema.addOneOf('double');
+
+    expect(schema.oneOf).toHaveLength(2);
+
+    schema.clearOneOf();
+
+    expect(schema.oneOf).toBeNull();
   });
 
   test('arrayOf', () => {

--- a/packages/openapi-model/src/3.0.3/model/index.ts
+++ b/packages/openapi-model/src/3.0.3/model/index.ts
@@ -1,3 +1,5 @@
 export * from './types';
 export { OpenAPIReader } from './OpenAPIReader';
 export { OpenAPIWriter } from './OpenAPIWriter';
+export { OpenAPIFactory } from './OpenAPI';
+export { SchemaFactory } from './Schema';

--- a/packages/openapi-model/src/3.0.3/model/types.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.test.ts
@@ -28,7 +28,7 @@ test('how easy is to use this class', () => {
   api.addServer('https://partners-app.fresha.com');
 
   const pathItem = api.setPathItem('/api/v1');
-  const operation = pathItem.addOperation('get');
+  const operation = pathItem.setOperation('get');
 
   expect(pathItem.get).toBe(operation);
 });
@@ -38,7 +38,7 @@ test('build schema - simple', () => {
   api.info.description = 'A sample API to illustrate OpenAPI concepts';
 
   const pathItem = api.setPathItem('/list');
-  const operation = pathItem.addOperation('get');
+  const operation = pathItem.setOperation('get');
   operation.description = 'Returns a list of stuff';
   operation.responses.setResponse(200, 'Successful response');
 
@@ -100,7 +100,7 @@ test('build schema - petstore', () => {
   // findPets
   //
 
-  const findPetsOperation = collectionPathItem.addOperation('get');
+  const findPetsOperation = collectionPathItem.setOperation('get');
   findPetsOperation.description = `Returns all pets from the system that the user has access to
 Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
 
@@ -131,7 +131,7 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
   // addPet
   //
 
-  const addPetOperation = collectionPathItem.addOperation('post');
+  const addPetOperation = collectionPathItem.setOperation('post');
   addPetOperation.description = 'Creates a new pet in the store. Duplicates are allowed';
   addPetOperation.operationId = 'addPet';
 
@@ -159,7 +159,7 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
   // find pet by id
   //
 
-  const getPetOperation = itemPathItem.addOperation('get');
+  const getPetOperation = itemPathItem.setOperation('get');
   getPetOperation.description =
     'Returns a user based on a single ID, if the user does not have access to the pet';
   getPetOperation.operationId = 'find pet by id';
@@ -180,7 +180,7 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
   // deletePet
   //
 
-  const deletePetOperation = itemPathItem.addOperation('delete');
+  const deletePetOperation = itemPathItem.setOperation('delete');
   deletePetOperation.description = 'deletes a single pet based on the ID supplied';
   deletePetOperation.operationId = 'deletePet';
 

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -46,12 +46,17 @@ export interface DiscriminatorModel extends Disposable, SpecificationExtensionsM
   readonly mapping: ReadonlyMap<string, string>;
 }
 
+/**
+ * Convenience type, used during schema creation.
+ */
 export type SchemaCreateType = null | SchemaType | SchemaFormat;
 
-export type SchemaCreatePropertyParams = {
-  type: SchemaCreateType;
+export type SchemaCreateObject = {
+  type: SchemaCreateType | SchemaModel;
   required?: boolean;
 };
+
+export type SchemaCreateOptions = SchemaCreateType | SchemaModel | SchemaCreateObject;
 
 /**
  * @see https://spec.openapis.org/oas/v3.0.3#schema-object
@@ -60,9 +65,9 @@ export interface SchemaModel extends Disposable, SpecificationExtensionsModel {
   title: Nullable<string>;
   multipleOf: Nullable<number>;
   maximum: Nullable<number>;
-  exclusiveMaximum: boolean;
+  exclusiveMaximum: Nullable<number>;
   minimum: Nullable<number>;
-  exclusiveMinimum: boolean;
+  exclusiveMinimum: Nullable<number>;
   maxLength: Nullable<number>;
   minLength: Nullable<number>;
   pattern: Nullable<string>;
@@ -93,39 +98,39 @@ export interface SchemaModel extends Disposable, SpecificationExtensionsModel {
   example: Nullable<JSONValue>;
   deprecated: boolean;
 
-  setProperty(name: string, type: SchemaCreateType | SchemaCreatePropertyParams): SchemaModel;
-  setProperties(props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>): SchemaModel;
+  setProperty(name: string, options: SchemaCreateOptions): SchemaModel;
+  setProperties(props: Record<string, SchemaCreateOptions>): SchemaModel;
   deleteProperty(name: string): void;
   clearProperties(): void;
 
   setPropertyRequired(name: string, value: boolean): void;
 
-  addAllOf(typeOrSchema: SchemaCreateType | SchemaModel): SchemaModel;
+  addAllOf(options: SchemaCreateOptions): SchemaModel;
   deleteAllOfAt(index: number): void;
   clearAllOf(): void;
+
+  addOneOf(options: SchemaCreateOptions): SchemaModel;
+  deleteOneOfAt(index: number): void;
+  clearOneOf(): void;
 
   arrayOf(parent: SchemaParent): SchemaModel;
 }
 
-export type SchemaCreateArrayParams = {
-  type: SchemaCreateType | SchemaModel;
+export type SchemaCreateArrayObject = {
+  itemsOptions: SchemaCreateOptions;
   minItems?: number;
   maxItems?: number;
 };
+
+export type SchemaCreateArrayOptions = SchemaCreateType | SchemaModel | SchemaCreateArrayObject;
 
 /**
  * This class provides convenience methods for creating SchemaObject-s.
  */
 export interface SchemaModelFactory {
-  create(parent: SchemaParent, params: SchemaCreateType): SchemaModel;
-  createArray(
-    parent: SchemaParent,
-    params: SchemaCreateType | SchemaCreateArrayParams | SchemaModel,
-  ): SchemaModel;
-  createObject(
-    parent: SchemaParent,
-    props: Record<string, SchemaCreateType | SchemaCreatePropertyParams>,
-  ): SchemaModel;
+  create(parent: SchemaParent, params: Exclude<SchemaCreateType, SchemaModel>): SchemaModel;
+  createArray(parent: SchemaParent, options: SchemaCreateArrayOptions): SchemaModel;
+  createObject(parent: SchemaParent, props: Record<string, SchemaCreateOptions>): SchemaModel;
 }
 
 /**
@@ -381,7 +386,7 @@ export interface PathItemModel extends Disposable, SpecificationExtensionsModel 
 
   operations(): IterableIterator<[HTTPMethod, OperationModel]>;
 
-  addOperation(method: HTTPMethod): OperationModel;
+  setOperation(method: HTTPMethod): OperationModel;
   removeOperation(method: HTTPMethod): void;
   clearOperations(): void;
 }
@@ -523,7 +528,7 @@ export interface ComponentsModel extends Disposable, SpecificationExtensionsMode
   readonly examples: ReadonlyMap<string, ExampleModel>;
   readonly requestBodies: ReadonlyMap<string, RequestBodyModel>;
   readonly headers: ReadonlyMap<string, HeaderModel>;
-  readonly securitySchemas: ReadonlyMap<string, SecuritySchemaModel>;
+  readonly securitySchemes: ReadonlyMap<string, SecuritySchemaModel>;
   readonly links: ReadonlyMap<string, LinkModel>;
   readonly callbacks: ReadonlyMap<string, CallbackModel>;
 
@@ -553,7 +558,7 @@ export interface ComponentsModel extends Disposable, SpecificationExtensionsMode
 
   setSecuritySchema(name: string, kind: SecuritySchemaModel['type']): SecuritySchemaModel;
   deleteSecuritySchema(name: string): void;
-  clearSecuritySchemas(): void;
+  clearSecuritySchemes(): void;
 
   setLink(name: string): LinkModel;
   deleteLink(name: string): void;
@@ -619,4 +624,9 @@ export interface OpenAPIModel extends Disposable, SpecificationExtensionsModel {
   deleteTag(name: string): void;
   deleteTagAt(index: number): void;
   clearTags(): void;
+}
+
+export interface OpenAPIModelFactory {
+  create(): OpenAPIModel;
+  create(title: string, version: string): OpenAPIModel;
 }

--- a/packages/openapi-model/src/3.0.3/types.ts
+++ b/packages/openapi-model/src/3.0.3/types.ts
@@ -142,9 +142,9 @@ export type SchemaObject = {
   title?: string;
   multipleOf?: number;
   maximum?: number;
-  exclusiveMaximum?: boolean;
+  exclusiveMaximum?: number;
   minimum?: number;
-  exclusiveMinimum?: boolean;
+  exclusiveMinimum?: number;
   maxLength?: number;
   minLength?: number;
   pattern?: string;
@@ -211,7 +211,7 @@ export type ComponentsObject = {
   examples?: Record<string, ObjectOrRef<ExampleObject>>;
   requestBodies?: Record<string, ObjectOrRef<RequestBodyObject>>;
   headers?: Record<string, ObjectOrRef<HeaderObject>>;
-  securitySchemas?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
+  securitySchemes?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
   links?: Record<string, ObjectOrRef<LinkObject>>;
   callbacks?: Record<string, ObjectOrRef<CallbackObject>>;
 } & SpecificationExtensions;

--- a/packages/openapi-model/src/3.1.0/types.ts
+++ b/packages/openapi-model/src/3.1.0/types.ts
@@ -141,7 +141,7 @@ export type ComponentsObject = {
   examples?: Record<string, ObjectOrRef<ExampleObject>>;
   requestBodies?: Record<string, ObjectOrRef<RequestBodyObject>>;
   headers?: Record<string, ObjectOrRef<HeaderObject>>;
-  securitySchemas?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
+  securitySchemes?: Record<string, ObjectOrRef<SecuritySchemeObject>>;
   links?: Record<string, ObjectOrRef<LinkObject>>;
   callbacks?: Record<string, ObjectOrRef<CallbackObject>>;
   pathItems?: Record<string, PathItemObject>;


### PR DESCRIPTION
## Motivation and Context

During work on NestJS code generators, the following bugs had to be fixed:

- proper handling of multi-level references in OpenAPI schemas (e.g. `PathItem` -> `RequestBody` -> `Schema` -> `Schema`)
- `Components.securitySchemas` was renamed to securitySchemes, according to the specification
- exposed `OpenAPIFactory` interface, to allow creation of OpenAPI models
- proper handling of `SchemaModel.exclusiveMaximum` and `SchemaModel.exclusiveMinimum`
- `PathItem.addOperation` was renamed to `PathItem.setOperation`, according to guidelines
- creation parameters of `SchemaModel` were unified among all factory methods of `Schema`
- `SchemaFactory` has been exposed, to allow creation of schema instances
- added `Schema.addOneOf`, `Schema.deleteOneOf` and `Schema.clearOneOf` methods

## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
