### PR TITLE
Remove unused dependency from openapi-model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6112,11 +6112,10 @@
     },
     "packages/openapi-model": {
       "name": "@fresha/openapi-model",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "0.2.0",
-        "@fresha/json-schema-model": "0.1.0",
         "yaml": "^2.1.1"
       },
       "devDependencies": {
@@ -7421,7 +7420,6 @@
         "@fresha/api-tools-core": "0.2.0",
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
-        "@fresha/json-schema-model": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "@types/node": "^18.0.0",
         "deep-object-diff": "^1.1.7",

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-model",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenAPI object model",
   "main": "build/index.js",
   "scripts": {
@@ -45,7 +45,6 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "0.2.0",
-    "@fresha/json-schema-model": "0.1.0",
     "yaml": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview

This PR removes `@fresha/json-schema-model` dependency from `@fresha/openapi-model`. It also bumps package version of the latter.