### PR TITLE
Bump version for @fresha/openapi-codegen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6128,7 +6128,7 @@
     },
     "packages/openapi-codegen": {
       "name": "@fresha/openapi-codegen",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@fresha/openapi-codegen-server-elixir": "^0.1.0",
@@ -6162,7 +6162,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@fresha/openapi-model": "0.1.0"
+        "@fresha/openapi-model": "0.2.1"
       },
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",
@@ -7505,7 +7505,7 @@
       "requires": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
-        "@fresha/openapi-model": "0.1.0",
+        "@fresha/openapi-model": "0.2.1",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }

--- a/packages/openapi-codegen/package.json
+++ b/packages/openapi-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenAPI code generation",
   "bin": {
     "fresha-openapi-codegen": "./bin/fresha-openapi-codegen.js"


### PR DESCRIPTION
## Motivation and Context

Bump package version for `@fresha/openapi-codegen`, to include Elixir codegen.
