### PR TITLE
Bump openapi-codegen version + register TS codegen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,13 @@ jobs:
       - run: npm run -w @fresha/json-api-model --if-present build && exit 0
       - run: npm run -w @fresha/json-schema-codegen --if-present build && exit 0
       - run: npm run -w @fresha/openapi-model --if-present build && exit 0
+      - run: npm run -w @fresha/openapi-codegen-client-typescript --if-present build &&
+          exit 0
       - run: npm run -w @fresha/openapi-codegen-server-nestjs --if-present build && exit
           0
       - run: npm run -w @fresha/openapi-codegen-server-elixir --if-present build && exit
           0
       - run: npm run -w @fresha/openapi-codegen --if-present build && exit 0
-      - run: npm run -w @fresha/openapi-codegen-client-typescript --if-present build &&
-          exit 0
       - run: npm run -w @fresha/openapi-diff --if-present build && exit 0
       - run: npm run -w @fresha/openapi-lint --if-present build && exit 0
       - run: npm run -w @fresha/openapi-validator --if-present build && exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -6128,9 +6128,10 @@
     },
     "packages/openapi-codegen": {
       "name": "@fresha/openapi-codegen",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
+        "@fresha/openapi-codegen-client-typescript": "^0.1.0",
         "@fresha/openapi-codegen-server-elixir": "^0.1.0",
         "@fresha/openapi-codegen-server-nestjs": "^0.1.0",
         "yargs": "^17.5.1"
@@ -7478,6 +7479,7 @@
       "requires": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
+        "@fresha/openapi-codegen-client-typescript": "^0.1.0",
         "@fresha/openapi-codegen-server-elixir": "^0.1.0",
         "@fresha/openapi-codegen-server-nestjs": "^0.1.0",
         "@fresha/typescript-config": "0.1.0",

--- a/packages/openapi-codegen-client-typescript/src/index.ts
+++ b/packages/openapi-codegen-client-typescript/src/index.ts
@@ -53,5 +53,10 @@ const handler = (args: ArgumentsCamelCase<Params>): void => {
 };
 
 export const register = (argv: Argv): void => {
-  argv.command('server-elixir', 'generates code for Elixir (Phoenix)', parser, handler);
+  argv.command(
+    'client-typescript',
+    '(experimental) generates code for TypeScript clients',
+    parser,
+    handler,
+  );
 };

--- a/packages/openapi-codegen/package.json
+++ b/packages/openapi-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenAPI code generation",
   "bin": {
     "fresha-openapi-codegen": "./bin/fresha-openapi-codegen.js"
@@ -54,6 +54,7 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
+    "@fresha/openapi-codegen-client-typescript": "^0.1.0",
     "@fresha/openapi-codegen-server-nestjs": "^0.1.0",
     "@fresha/openapi-codegen-server-elixir": "^0.1.0",
     "yargs": "^17.5.1"

--- a/packages/openapi-codegen/src/index.ts
+++ b/packages/openapi-codegen/src/index.ts
@@ -1,3 +1,4 @@
+import { register as registerClientCodegen } from '@fresha/openapi-codegen-client-typescript';
 import { register as registerElixirCodegen } from '@fresha/openapi-codegen-server-elixir';
 import { register as registerNestJSCodegen } from '@fresha/openapi-codegen-server-nestjs';
 import yargs from 'yargs';
@@ -5,6 +6,7 @@ import { hideBin } from 'yargs/helpers';
 
 const argv = yargs(hideBin(process.argv)).usage('Usage');
 
+registerClientCodegen(argv);
 registerNestJSCodegen(argv);
 registerElixirCodegen(argv);
 


### PR DESCRIPTION
## Overview

This PR:

- registers `client-typescript` codegen
- bumps `openapi-codegen` version, in order to publish it